### PR TITLE
Error while generating HTML report, issue #40

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -498,14 +498,14 @@ Report.mix(HtmlReport, {
         tree = summarizer.getTreeSummary();
         fs.readdirSync(path.resolve(__dirname, '..', 'vendor')).forEach(function (f) {
             var resolvedSource = path.resolve(__dirname, '..', 'vendor', f),
-						          resolvedDestination = path.resolve(dir, f),
-						          stat = fs.statSync(resolvedSource);
+                resolvedDestination = path.resolve(dir, f),
+                stat = fs.statSync(resolvedSource);
 
-					       if (stat.isFile()) {
-						          if (opts.verbose) {
-							             console.log('Write asset: ' + resolvedDestination);
-						          }
-						          writer.copyFile(resolvedSource, resolvedDestination);
+            if (stat.isFile()) {
+                if (opts.verbose) {
+                    console.log('Write asset: ' + resolvedDestination);
+                }
+                writer.copyFile(resolvedSource, resolvedDestination);
             }
         });
         //console.log(JSON.stringify(tree.root, undefined, 4));


### PR DESCRIPTION
When istanbul module is commited in a SVN repository, generating a HTML report produce the error :

Fatal error: EISDIR, illegal operation on a directory

This is due to the presence of the .svn directory
