### PR TITLE
Jenkins cobertura line level details fix

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -81,7 +81,7 @@ function addClassStats(node, fileCoverage, writer) {
 
     writer.println('\t\t<class' +
         attr('name', asClassName(node)) +
-        attr('filename', node.fullPath()) +
+        attr('filename', node.name) +
         attr('line-rate', metrics.lines.pct / 100.0) +
         attr('branch-rate', metrics.branches.pct / 100.0) +
         '>');


### PR DESCRIPTION
There is an issue with using full paths for filenames in the jenkins cobertura plugin, switching to relative paths fixes this.
