### PR TITLE
Jenkins Cobertura plugin does not record method based coverage

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -81,7 +81,7 @@ function addClassStats(node, fileCoverage, writer) {
 
     writer.println('\t\t<class' +
         attr('name', asClassName(node)) +
-        attr('filename', node.name) +
+        attr('filename', node.fullPath()) +
         attr('line-rate', metrics.lines.pct / 100.0) +
         attr('branch-rate', metrics.branches.pct / 100.0) +
         '>');


### PR DESCRIPTION
Allow jenkins cobertura plugin to record method coverage. Certainly feels hacky and ideally all lines within the function would be listed under the method node of the report. I didn't see an easy way to slice the lines by function and this patch works for that purpose.
