### PR TITLE
Add <source> path and make class filenames relative to the source path

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -82,7 +82,7 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
 
     writer.println('\t\t<class' +
         attr('name', asClassName(node)) +
-        attr('filename', node.fullPath().replace(projectRoot + '/', '')) +
+        attr('filename', node.fullPath().replace(projectRoot + (path.sep || '/'), '')) +
         attr('line-rate', metrics.lines.pct / 100.0) +
         attr('branch-rate', metrics.branches.pct / 100.0) +
         '>');


### PR DESCRIPTION
This fixes gotwarlost/istanbul#50 by giving source paths where Jenkins
can find the source files in order to archive them and paint the source
with proper coverage styles.
