### PR TITLE
at exit, no console output if opts.print === 'none'

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -170,13 +170,17 @@ function run(args, commandName, enableHooks, callback) {
                     //important: there is no event loop at this point
                     //everything that happens in this exit handler MUST be synchronous
                     mkdirp.sync(reportingDir); //yes, do this again since some test runners could clean the dir initially created
-                    console.error('=============================================================================');
-                    console.error('Writing coverage object [' + file + ']');
+                    if (opts.print !== 'none') {
+                        console.error('=============================================================================');
+                        console.error('Writing coverage object [' + file + ']');
+                    }
                     fs.writeFileSync(file, JSON.stringify(cov), 'utf8');
                     collector = new Collector();
                     collector.add(cov);
-                    console.error('Writing coverage reports at [' + reportingDir + ']');
-                    console.error('=============================================================================');
+                    if (opts.print !== 'none') {
+                        console.error('Writing coverage reports at [' + reportingDir + ']');
+                        console.error('=============================================================================');
+                    }
                     reports.forEach(function (report) {
                         report.writeReport(collector, true);
                     });


### PR DESCRIPTION
Not a big point, but seems to me if opt.print === 'none', then that should apply to these console.error messages.
