### PR TITLE
LcovReporter should forward sourceStore into HtmlReporter

### DIFF
--- a/lib/report/lcov.js
+++ b/lib/report/lcov.js
@@ -34,7 +34,7 @@ function LcovReport(opts) {
 
     mkdirp.sync(baseDir);
     this.lcov = new LcovOnlyReport({ dir: baseDir });
-    this.html = new HtmlReport({ dir: htmlDir });
+    this.html = new HtmlReport({ dir: htmlDir, sourceStore: opts.sourceStore});
 }
 
 LcovReport.TYPE = 'lcov';


### PR DESCRIPTION
It's based on this Karma issue: https://github.com/karma-runner/karma/issues/528

I believe it should forward all the options.
