### PR TITLE
fixes #79

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -464,7 +464,7 @@ Report.mix(HtmlReport, {
                     i,
                     j;
                 for (i = 0; i < num; i += 1) {
-                    separated = node.relativeName.split(SEP);
+                    separated = node.relativeName.split('/');
                     levels = separated.length - 1;
                     for (j = 0; j < levels; j += 1) {
                         href += '../';


### PR DESCRIPTION
Substituted `SEP` for `'/'`, because even though `require('path').sep == \` on Windows, `node.relativeName` is built with `/` as the folder separator. Therefore, `node.relativeName.split(SEP)` produced `['some/path\', '']` when it should produce `['some', 'path\']`.
