### PR TITLE
Text reporter - colours support

### DIFF
--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -62,13 +62,14 @@ function fill(str, width, right, tabs) {
         fmtStr = '',
         fillStr,
         isNumber = !isNaN(parseFloat(str)) && isFinite(str),
-        strlen = str.length;
+        strlen = str.length,
+        isTty = Boolean(process.stdout.isTTY);
 
-    if (isNumber) {
-        // low: < 75 % medium: >= 75 % high: >= 90 %
-        if (str >= 90) {
+    if (isNumber && isTty) {
+        // low: < 50 % medium: >= 50 % high: >= 80 %
+        if (str >= 80) {
             str = '\033[92m' + str + '\033[0m'; // high - green
-        } else if (str >= 75) {
+        } else if (str >= 50) {
             str = '\033[93m' + str + '\033[0m'; // medium - yellow
         } else {
             str = '\033[91m' + str + '\033[0m'; // low - red


### PR DESCRIPTION
I've added colors support, so now text reporter's output looks like this:

![screen shot 2013-07-25 at 3 53 14 pm](https://f.cloud.github.com/assets/903687/853820/6ade42b0-f4ef-11e2-8c19-86bf40aa3549.png)
