### PR TITLE
Check for null element in the branch array, fixes issue #56

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -245,6 +245,9 @@ function annotateBranches(fileCoverage, structuredText) {
 
         if (sumCount > 0) { //only highlight if partial branches are missing
             for (i = 0; i < branchArray.length; i += 1) {
+                if(branchArray[i] === null) {
+                    continue;
+                }
                 count = branchArray[i];
                 meta = metaArray[i];
                 type = count > 0 ? 'yes' : 'no';


### PR DESCRIPTION
In my case I found that branchArray sometimes contained a null element at the end. When skipping such elements I was able to get the html report generated. Probably there is a root cause that should be fixed instead?
