### PR TITLE
Add a summary reporter for running tests in Teamcity

### DIFF
--- a/lib/report/teamcity-summary.js
+++ b/lib/report/teamcity-summary.js
@@ -3,10 +3,7 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-var path = require('path'),
-    mkdirp = require('mkdirp'),
-    fs = require('fs'),
-    utils = require('../object-utils'),
+var utils = require('../object-utils'),
     Report = require('./index');
 
 /**


### PR DESCRIPTION
Outputs messages on the console that Teamcity will pick up and use for gathering test coverage statistics
