### PR TITLE
Use console.error instead of deprecated util.error

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,7 +8,6 @@
 
 var Command = require('./command'),
     inputError = require('./util/input-error'),
-    util = require('util'),
     exit = process.exit; //hold a reference to original process.exit so that we are not affected even when a test changes it
 
 require('./register-plugins');
@@ -31,8 +30,8 @@ function errHandler (ex) {
         throw ex; // turn it into an uncaught exception
     } else {
         //don't print nasty traces but still exit(1)
-        util.error(ex.message);
-        util.error('Try "istanbul help" for usage');
+        console.error(ex.message);
+        console.error('Try "istanbul help" for usage');
         exit(1);
     }
 }

--- a/lib/command/check-coverage.js
+++ b/lib/command/check-coverage.js
@@ -26,7 +26,7 @@ Command.mix(CheckCoverageCommand, {
     },
 
     usage: function () {
-        util.error('\nUsage: ' + this.toolName() + ' ' + this.type() + ' <options> [<include-pattern>]\n\nOptions are:\n\n' +
+        console.error('\nUsage: ' + this.toolName() + ' ' + this.type() + ' <options> [<include-pattern>]\n\nOptions are:\n\n' +
             [
                 formatOption('--statements <threshold>', 'statement coverage threshold'),
                 formatOption('--functions <threshold>', 'function coverage threshold'),
@@ -34,16 +34,16 @@ Command.mix(CheckCoverageCommand, {
                 formatOption('--lines <threshold>', 'line coverage threshold')
             ].join('\n\n') + '\n');
 
-        util.error('\n\n');
+        console.error('\n\n');
 
-        util.error('Thresholds, when specified as a positive number are taken to be the minimum percentage required.');
-        util.error('When a threshold is specified as a negative number it represents the maximum number of uncovered entities allowed.\n');
-        util.error('For example, --statements 90 implies minimum statement coverage is 90%.');
-        util.error('             --statements -10 implies that no more than 10 uncovered statements are allowed\n');
-        util.error('<include-pattern> is a fileset pattern that can be used to select one or more coverage files ' +
+        console.error('Thresholds, when specified as a positive number are taken to be the minimum percentage required.');
+        console.error('When a threshold is specified as a negative number it represents the maximum number of uncovered entities allowed.\n');
+        console.error('For example, --statements 90 implies minimum statement coverage is 90%.');
+        console.error('             --statements -10 implies that no more than 10 uncovered statements are allowed\n');
+        console.error('<include-pattern> is a fileset pattern that can be used to select one or more coverage files ' +
             'for merge. This defaults to "**/coverage*.json"');
 
-        util.error('\n');
+        console.error('\n');
     },
 
     run: function (args, callback) {

--- a/lib/command/help.js
+++ b/lib/command/help.js
@@ -22,18 +22,18 @@ Command.mix(HelpCommand, {
 
     usage: function () {
 
-        util.error('\nUsage: ' + this.toolName() + ' ' + this.type() + ' <command>\n');
-        util.error('Available commands are:\n');
+        console.error('\nUsage: ' + this.toolName() + ' ' + this.type() + ' <command>\n');
+        console.error('Available commands are:\n');
 
         var commandObj;
         Command.getCommandList().forEach(function (cmd) {
             commandObj = Command.create(cmd);
-            util.error(formatOption(cmd, commandObj.synopsis()));
-            util.error("\n");
+            console.error(formatOption(cmd, commandObj.synopsis()));
+            console.error("\n");
         });
-        util.error("Command names can be abbreviated as long as the abbreviation is unambiguous");
-        util.error(this.toolName() + ' version:' + VERSION);
-        util.error("\n");
+        console.error("Command names can be abbreviated as long as the abbreviation is unambiguous");
+        console.error(this.toolName() + ' version:' + VERSION);
+        console.error("\n");
     },
     run: function (args, callback) {
         var command;
@@ -44,7 +44,7 @@ Command.mix(HelpCommand, {
                 command = Command.create(args[0]);
                 command.usage('istanbul', Command.resolveCommandName(args[0]));
             } catch (ex) {
-                util.error('Invalid command: ' + args[0]);
+                console.error('Invalid command: ' + args[0]);
                 this.usage();
             }
         }


### PR DESCRIPTION
Node 0.11 complains that `util.error` shouldn't be used.
