### PR TITLE
ES6 Yield expression

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -102,8 +102,8 @@
         VariableDeclaration: [ 'declarations' ],
         VariableDeclarator: [ 'id', 'init' ],
         WhileStatement: [ 'test', 'body' ],
-        WithStatement: [ 'object', 'body' ]
-
+        WithStatement: [ 'object', 'body' ],
+        YieldExpression: ['argument']
     };
 
     for (nodeType in SYNTAX) {


### PR DESCRIPTION
This adds support for `yield` _if_ "harmony" branch of esprima is used. 

Since harmony version of esprima is unreleased yet I haven't added it as a dependency (I've bumped versions to latest stable though). 

This change is future-proofing at this point (but if you [upgrade esprima](https://github.com/pornel/istanbul/commit/7a12a249ba49a083e1e97d4cf26aa8b22cde07bd) it works). 
