### PR TITLE
Use path.relative to get relative path in class filenames vs the source path

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -82,7 +82,7 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
 
     writer.println('\t\t<class' +
         attr('name', asClassName(node)) +
-        attr('filename', node.fullPath().replace(projectRoot + (path.sep || '/'), '')) +
+        attr('filename', path.relative(projectRoot, node.fullPath())) +
         attr('line-rate', metrics.lines.pct / 100.0) +
         attr('branch-rate', metrics.branches.pct / 100.0) +
         '>');


### PR DESCRIPTION
Jenkins cannot show source code from cobertura report
gotwarlost#50

Add path and make class filenames relative to the source path
gotwarlost#51

If js source files are not under projectRoot the fix in issue #51 won't work. Changed to use path.relative() to get relative path. 
