### PR TITLE
Support refresh to reload with Mr

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ Copyrights licensed under the New BSD License. See the accompanying LICENSE file
 /*jslint nomen: true */
 var path = require('path'),
     fs = require('fs'),
-    Store = require('./lib/store'),
-    Report = require('./lib/report'),
+    Store = require('./lib/store/index'),
+    Report = require('./lib/report/index'),
     meta = require('./lib/util/meta');
 
 //register our standard plaugins

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@
  */
 
 
-var Command = require('./command'),
+var Command = require('./command/index'),
     inputError = require('./util/input-error'),
     exit = process.exit; //hold a reference to original process.exit so that we are not affected even when a test changes it
 

--- a/lib/command/report.js
+++ b/lib/command/report.js
@@ -4,7 +4,7 @@
  */
 
 var nopt = require('nopt'),
-    Report = require('../report'),
+    Report = require('../report/index'),
     path = require('path'),
     fs = require('fs'),
     Collector = require('../collector'),

--- a/lib/register-plugins.js
+++ b/lib/register-plugins.js
@@ -3,13 +3,11 @@
  Copyright (c) 2012, Yahoo! Inc.  All rights reserved.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-var Store = require('./store'),
-    Report = require('./report'),
-    Command = require('./command');
+var Store = require('./store/index'),
+    Report = require('./report/index'),
+    Command = require('./command/index');
 
 Store.loadAll();
 Report.loadAll();
 Command.loadAll();
-
-
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "posttest": "node ./lib/cli.js check-coverage --statements 95 --branches 80",
         "docs": "npm install yuidocjs && node node_modules/yuidocjs/lib/cli.js ."
     },
+    "main": "index.js",
     "bin": {
         "istanbul": "./lib/cli.js"
     },

--- a/test/other/test-command-xface.js
+++ b/test/other/test-command-xface.js
@@ -1,4 +1,4 @@
-var Command = require('../../lib/command');
+var Command = require('../../lib/command/index');
 
 module.exports = {
     "should return command list": function (test) {


### PR DESCRIPTION
[Mr](https://github.com/montagejs/mr) and [Mop](https://github.com/montagejs/mop) serve a similar function to [Browserify](https://github.com/substack/node-browserify) but
supports refresh-to-reload during development using Mr and whole package
application transformation with Mop. Thus a build step is not necessary
during development, and transforming packages for use in production does
not require any configuration changes in source. These loaders support
Node.js modules and packages with very high fidelity, inferring where
npm installed packages, but with one major caveat, that they cannot
infer the existence of an `index.js` file during development. To avoid
this gotcha, this change adds a `main` property to `package.json`
pointing to the root-level `index.js`, and alters usage of the other
index modules by explicating the `index` at the end of the module
identifier.
