### PR TITLE
Unifies the documentation in the README and usage help

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and function coverage** and reverse-engineers **line coverage** with 100% fideli
 * **Module loader hooks** to instrument code on the fly
 * **Command line tools** to run node unit tests "with coverage turned on" and no cooperation
 whatsoever from the test runner
-* **HTML**, **LCOV**, **Cobertura**, and **TeamCity** reporting.
+* **HTML**, **LCOV**, **Cobertura**, **TeamCity**, and **Clover** reporting.
 * Ability to use as **middleware** when serving JS files that need to be tested on the browser.
 * Can be used on the **command line** as well as a **library**
 * Based on the awesome `esprima` parser and the equally awesome `escodegen` code generator
@@ -155,6 +155,7 @@ Writes reports using `coverage*.json` files as the source of coverage informatio
 * text-summary - produces a compact text summary of coverage, typically to console
 * text - produces a detailed text table with coverage for all files
 * teamcity - produces service messages to report code coverage to TeamCity
+* clover - produces a clover.xml file to integrate with Atlassian Clover
 
 Additional report formats may be plugged in at the library level.
 

--- a/lib/command/report.js
+++ b/lib/command/report.js
@@ -39,7 +39,7 @@ Command.mix(ReportCommand, {
         console.error('\n');
 
         console.error('<format> is one of html, lcovonly, lcov (html + lcovonly), cobertura, text-summary, text, ' +
-            ' or teamcity. Default is lcov');
+            'teamcity, or clover. Default is lcov');
         console.error('<include-pattern> is a fileset pattern that can be used to select one or more coverage files ' +
             'for merged reporting. This defaults to "**/coverage*.json"');
 


### PR DESCRIPTION
Adds the full list of available report formats from the README into the usage, and puts the documentation from the usage for the `check-coverage` command into the README, where it was previously undocumented.
