### PR TITLE
Update to the latest stable Esprima 1.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "url": "git://github.com/gotwarlost/istanbul.git"
     },
     "dependencies": {
-        "esprima": "1.0.x",
+        "esprima": "1.1.x",
         "escodegen": "1.3.x",
         "handlebars": "1.3.x",
         "mkdirp": "0.3.x",


### PR DESCRIPTION
Use the latest Esprima. Running `npm test` doesn't show any regression.
When Istanbul is processing a large file, the instrumentation step is faster typically by almost 2x.
