### PR TITLE
Read reports from the config file

### DIFF
--- a/lib/command/report.js
+++ b/lib/command/report.js
@@ -56,7 +56,6 @@ Command.mix(ReportCommand, {
             },
             opts = nopt(template, { v : '--verbose' }, args, 0),
             fmtAndArgs = opts.argv.remain,
-            fmt = 'lcov',
             includePattern = '**/coverage*.json',
             reporter,
             root,
@@ -70,8 +69,10 @@ Command.mix(ReportCommand, {
             reportOpts = {
                 verbose: config.verbose,
                 dir: config.reporting.dir(),
-                watermarks: config.reporting.watermarks()
-            };
+                watermarks: config.reporting.watermarks(),
+                reports: config.reporting.reports()
+            },
+            fmt = reportOpts.reports[0];
 
         if (fmtAndArgs.length > 0) {
             fmt = fmtAndArgs[0];

--- a/test/cli/sample-project/config.istanbul.yml
+++ b/test/cli/sample-project/config.istanbul.yml
@@ -1,0 +1,4 @@
+reporting:
+  reports:
+    - cobertura
+    - html

--- a/test/cli/test-report-command.js
+++ b/test/cli/test-report-command.js
@@ -61,5 +61,13 @@ module.exports = {
             test.equal('', fs.readFileSync(path.resolve(OUTPUT_DIR, 'lcov.info'), 'utf8'));
             test.done();
         });
+    },
+    "should default to configuration value": function (test) {
+        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+        run([ '--report', '--config', 'config.istanbul.yml' ], function (results) {
+            test.ok(results.succeeded());
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'cobertura-coverage.xml')));
+            test.done();
+        });
     }
 };


### PR DESCRIPTION
So far the `reporting.reports` of the configuration file is ignored.

There is a test that verifies that the configuration is correct in `other/test-configuration.js`

``` js
    "when loading files": {
        "when files present": {
           "should use default YAML config when not explicit": function (test) {
                config = configuration.loadFile(undefined, { verbose: true });
                test.equal(false, config.instrumentation.compact());
                test.deepEqual(['lcov', 'cobertura'], config.reporting.reports());
                test.done();
            }
        }
    },
```

but this configuration is never used inside the reporter.

I've added a test, it passes on my machine (Windows) but I'm not sure if I screwed up something else because some tests fails already on Windows.
