### PR TITLE
handle sigint exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Istanbul - a JS code coverage tool written in JS
 [![Build Status](https://secure.travis-ci.org/gotwarlost/istanbul.png)](http://travis-ci.org/gotwarlost/istanbul)
 [![Dependency Status](https://gemnasium.com/gotwarlost/istanbul.png)](https://gemnasium.com/gotwarlost/istanbul)
 
-[![NPM](https://nodei.co/npm/istanbul.png?downloads=true)](https://nodei.co/npm/istanbul/) 
+[![NPM](https://nodei.co/npm/istanbul.png?downloads=true)](https://nodei.co/npm/istanbul/)
 
 Features
 --------
@@ -109,6 +109,8 @@ The `cover` command
 The `cover` command can be used to get a coverage object and reports for any arbitrary
 node script. By default, coverage information is written under `./coverage` - this
 can be changed using command-line options.
+
+The `cover` command can also be passed an optional `--handle-sigint` flag to enable writing reports when a user triggers a manual SIGINT of the process that is being covered. This can be useful when you are generating coverage for a long lived process.
 
 The `test` command
 -------------------
@@ -219,5 +221,3 @@ Why the funky name?
 -------------------
 
 Since all the good ones are taken. Comes from the loose association of ideas across coverage, carpet-area coverage, the country that makes good carpets and so on...
-
-

--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -70,7 +70,8 @@ function run(args, commandName, enableHooks, callback) {
             },
             hooks: {
                 'hook-run-in-context': opts['hook-run-in-context'],
-                'post-require-hook': opts['post-require-hook']
+                'post-require-hook': opts['post-require-hook'],
+                'handle-sigint': opts['handle-sigint']
             }
         },
         config = configuration.loadFile(opts.config, overrides),
@@ -182,6 +183,13 @@ function run(args, commandName, enableHooks, callback) {
 
                 //initialize the global variable to stop mocha from complaining about leaks
                 global[coverageVar] = {};
+
+                // enable passing --handle-sigint to write reports on SIGINT.
+                // This allows a user to manually kill a process while
+                // still getting the istanbul report.
+                if (config.hooks.config['handle-sigint']) {
+                    process.once('SIGINT', process.exit);
+                }
 
                 process.once('exit', function () {
                     var file = path.resolve(reportingDir, 'coverage.json'),

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -31,7 +31,8 @@ function defaultConfig() {
         },
         hooks: {
             'hook-run-in-context': false,
-            'post-require-hook': null
+            'post-require-hook': null,
+            'handle-sigint': false
         }
     };
     ret.reporting.watermarks = defaults.watermarks();


### PR DESCRIPTION
Useful when you have a long running process
that you want to test coverage of using an integration
test.
