### PR TITLE
Update to the latest stable Esprima 1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "url": "git://github.com/gotwarlost/istanbul.git"
     },
     "dependencies": {
-        "esprima": "1.1.x",
+        "esprima": "1.2.x",
         "escodegen": "1.3.x",
         "handlebars": "1.3.x",
         "mkdirp": "0.3.x",


### PR DESCRIPTION
Use the latest Esprima. Running `npm test` doesn't show any regression.

For details on version 1.2: https://groups.google.com/d/msg/esprima/3rez3UmVMaM/W_RDRTbFuo0J.
