### PR TITLE
Read the report configuration file from the options

### DIFF
--- a/lib/command/report.js
+++ b/lib/command/report.js
@@ -70,7 +70,8 @@ Command.mix(ReportCommand, {
             reportOpts = {
                 verbose: config.verbose,
                 dir: config.reporting.dir(),
-                watermarks: config.reporting.watermarks()
+                watermarks: config.reporting.watermarks(),
+                file: config.reporting.file()
             };
 
         if (fmtAndArgs.length > 0) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -27,7 +27,8 @@ function defaultConfig() {
         reporting: {
             print: 'summary',
             reports: [ 'lcov' ],
-            dir: './coverage'
+            dir: './coverage',
+            file: ''
         },
         hooks: {
             'hook-run-in-context': false,
@@ -115,7 +116,7 @@ function ReportingOptions(config) {
     this.config = config;
 }
 
-addMethods(ReportingOptions, 'print', 'reports', 'dir');
+addMethods(ReportingOptions, 'print', 'reports', 'dir', 'file');
 
 function isInvalidMark(v, key) {
     var prefix = 'Watermark for [' + key + '] :';


### PR DESCRIPTION
This PR is very similar to #179

Reports are already trying to read the destination file name from the options, but this value is always undefined (except in tests perhaps).

See for instance the cobertura report

``` js
function CoberturaReport(opts) {
    Report.call(this);
    opts = opts || {};
    this.projectRoot = process.cwd();
    this.dir = opts.dir || this.projectRoot;
    this.file = opts.file || 'cobertura-coverage.xml';  // <-- look, here
```

This pull requests propagates the value `opts.file` from `.istanbul.yml` to reports, giving the possibility to write to a different file name.

Btw, I've tried with

```
istanbul report --file coverage.xml cobertura
```

but this does not generate any report at all
