### PR TITLE
make link protocols relative so they don't break on https connections

### DIFF
--- a/lib/report/templates/foot.txt
+++ b/lib/report/templates/foot.txt
@@ -6,7 +6,7 @@
 {{#if prettify}}
 <script src="{{prettify.js}}"></script>
 {{/if}}
-<script src="//yui.yahooapis.com/3.6.0/build/yui/yui-min.js"></script>
+<script src="//yui-s.yahooapis.com/3.6.0/build/yui/yui-min.js"></script>
 <script>
 
     YUI().use('datatable', function (Y) {

--- a/lib/report/templates/head.txt
+++ b/lib/report/templates/head.txt
@@ -154,7 +154,7 @@
             margin-left: 0.5em;
         }
         div.coverage-summary .yui3-datatable-sort-indicator {
-            background: url("//yui.yahooapis.com/3.6.0/build/datatable-sort/assets/skins/sam/sort-arrow-sprite.png") no-repeat scroll 0 0 transparent;
+            background: url("//yui-s.yahooapis.com/3.6.0/build/datatable-sort/assets/skins/sam/sort-arrow-sprite.png") no-repeat scroll 0 0 transparent;
         }
         div.coverage-summary .yui3-datatable-sorted .yui3-datatable-sort-indicator {
             background-position: 0 -20px;


### PR DESCRIPTION
Should be pretty self explanatory. Chrome blocks scripts and images that don't match the protocol if browsing on an https site, and this should keep it happy.
