### PR TITLE
Fix for ignored branches and functions in cobertura report

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -118,7 +118,7 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
             '\t\t\t\t<lines>' +
              '<line' +
             attr('number', fnMap[k].line) +
-            attr('hits', fileCoverage.f[k]) +
+            attr('hits', hits) +
             '/>' +
             '</lines>'
         );


### PR DESCRIPTION
Cobertura reporter didn't increment number of hits in ignored branches and functions. The pull request fix it.
