### PR TITLE
report/text: change delimiter so summary table is valid markdown

### DIFF
--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -13,7 +13,7 @@ var path = require('path'),
     PCT_COLS = 10,
     TAB_SIZE = 3,
     DELIM = ' |',
-    COL_DELIM = '-+';
+    COL_DELIM = '-|';
 
 /**
  * a `Report` implementation that produces text output in a detailed table.


### PR DESCRIPTION
This one-character change makes it possible to select istanbul output in a terminal and have it display as a table when pasted directly anywhere markdown is expected (e.g., here, in a github comment).  Example:

| File | % Stmts | % Branches | % Funcs | % Lines |
| --- | --- | --- | --- | --- |
| lib\ | 97.06 | 91.58 | 95 | 98.17 |
| npo.src.js | 97.06 | 91.58 | 95 | 98.17 |

Before, I had to manually replace + with |.
