### PR TITLE
Support reporting within symlink/junction

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,5 +1,6 @@
 lib/vendor
 test/cli/sample-project
+test/cli/sample-project-link
 test/browser/support/vendor
 
 

--- a/lib/util/file-matcher.js
+++ b/lib/util/file-matcher.js
@@ -3,7 +3,9 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-var fileset = require('fileset'),
+var async = require('async'),
+    fileset = require('fileset'),
+    fs = require('fs'),
     path = require('path'),
     seq = 0;
 
@@ -17,6 +19,7 @@ function filesFor(options, callback) {
     var root = options.root,
         includes = options.includes,
         excludes = options.excludes,
+        realpath = options.realpath,
         relative = options.relative,
         opts;
 
@@ -29,10 +32,18 @@ function filesFor(options, callback) {
     opts['x' + seq + new Date().getTime()] = true; //cache buster for minimatch cache bug
     fileset(includes.join(' '), excludes.join(' '), opts, function (err, files) {
         if (err) { return callback(err); }
-        if (!relative) {
+        if (relative) { return callback(err, files); }
+
+        if (!realpath) {
             files = files.map(function (file) { return path.resolve(root, file); });
+            return callback(err, files);
         }
-        callback(err, files);
+
+        var realPathCache = module.constructor._realpathCache || {};
+
+        async.map(files, function (file, done) {
+            fs.realpath(path.resolve(root, file), realPathCache, done);
+        }, callback);
     });
 }
 
@@ -44,6 +55,7 @@ function matcherFor(options, callback) {
     }
     options = options || {};
     options.relative = false; //force absolute paths
+    options.realpath = true; //force real paths (to match Node.js module paths)
 
     filesFor(options, function (err, files) {
         var fileMap = {},


### PR DESCRIPTION
This changes the matcher for source files to get the file list as real paths (resolving links) such that when the matcher checks if the file is covered from the Node.js core module path, it actually matches, since it uses realpath.

The way my Windows machines are setup, to run istanbul on code, I have to change to other drives instead of just staying on C: because istanbul is not resolving through the NTFS junctions (similar to symlinks), which is really annoying.

I originally figured this out here https://github.com/gotwarlost/istanbul/issues/197#issuecomment-43960909

This fixes #206
