### PR TITLE
Add nodejs 0.6 support.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@
  */
 var path = require('path'),
     fs = require('fs'),
+    existsSync = fs.existsSync || path.existsSync,
     CAMEL_PATTERN = /([a-z])([A-Z])/g,
     YML_PATTERN = /\.ya?ml$/,
     yaml = require('js-yaml'),
@@ -379,11 +380,11 @@ function loadFile(file, overrides) {
         configObject;
 
     if (file) {
-        if (!fs.existsSync(file)) {
+        if (!existsSync(file)) {
             throw new Error('Invalid configuration file specified:' + file);
         }
     } else {
-        if (fs.existsSync(defaultConfigFile)) {
+        if (existsSync(defaultConfigFile)) {
             file = defaultConfigFile;
         }
     }


### PR DESCRIPTION
"fs.existsSync" method is not supported by nodejs 0.6. It should have a fallback to "path.existsSync" method.
