### PR TITLE
Fix tests to be portable to Windows

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,9 +6,10 @@
  */
 
 
-var Command = require('./command'),
+var async = require('async'),
+    Command = require('./command'),
     inputError = require('./util/input-error'),
-    exit = process.exit; //hold a reference to original process.exit so that we are not affected even when a test changes it
+    exitProcess = process.exit; //hold a reference to original process.exit so that we are not affected even when a test changes it
 
 require('./register-plugins');
 
@@ -24,15 +25,33 @@ function findCommandPosition(args) {
     return -1;
 }
 
+function exit(ex, code) {
+  // flush output for Node.js Windows pipe bug
+  // https://github.com/joyent/node/issues/6247 is just one bug example
+  // https://github.com/visionmedia/mocha/issues/333 has a good discussion
+  var streams = [process.stdout, process.stderr];
+  async.forEach(streams, function (stream, done) {
+    // submit a write request and wait until it's written
+    stream.write('', done);
+  }, function () {
+    if (ex) {
+        throw ex; // turn it into an uncaught exception
+    } else {
+        exitProcess(code);
+    }
+  });
+}
+
 function errHandler (ex) {
     if (!ex) { return; }
     if (!ex.inputError) {
-        throw ex; // turn it into an uncaught exception
+        // exit with exception stack trace
+        exit(ex);
     } else {
         //don't print nasty traces but still exit(1)
         console.error(ex.message);
         console.error('Try "istanbul help" for usage');
-        exit(1);
+        exit(null, 1);
     }
 }
 
@@ -54,6 +73,7 @@ function runCommand(args, callback) {
         commandObject = Command.create(command);
     } catch (ex) {
         errHandler(inputError.create(ex.message));
+        return;
     }
     commandObject.run(commandArgs, errHandler);
 }

--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -163,6 +163,8 @@ function run(args, commandName, enableHooks, callback) {
                             postLoadHookFile = resolve.sync(postRequireHook, { basedir: process.cwd() });
                         } catch (ex) {
                             if (verbose) { console.error('Unable to resolve [' + postRequireHook + '] as a node module'); }
+                            callback(ex);
+                            return;
                         }
                     }
                 }

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -141,7 +141,7 @@ TreeSummary.prototype = {
             node.name = node.name.substring(1);
         }
         if (parent) {
-            if (parent.name !== '__root__/') {
+            if (parent.name !== '__root__' + SEP) {
                 node.relativeName = node.name.substring(parent.name.length);
             } else {
                 node.relativeName = node.name;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "preferGlobal": true,
     "scripts": {
         "pretest": "jshint index.js lib/ test/",
-        "test": "test/run.js",
+        "test": "node test/run.js",
         "posttest": "node ./lib/cli.js check-coverage --statements 95 --branches 80",
         "docs": "npm install yuidocjs && node node_modules/yuidocjs/lib/cli.js ."
     },

--- a/test/cli/test-cover-command.js
+++ b/test/cli/test-cover-command.js
@@ -151,8 +151,10 @@ module.exports = {
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
             var coverage = JSON.parse(fs.readFileSync(path.resolve(OUTPUT_DIR, 'coverage.json'), 'utf8')),
+                ipsumPath = path.join('amd', 'ipsum'),
+                loremPath = path.join('amd', 'lorem'),
                 filtered;
-            filtered = Object.keys(coverage).filter(function (k) { return k.match(/amd\/lorem/) || k.match(/amd\/ipsum/); });
+            filtered = Object.keys(coverage).filter(function (k) { return k.indexOf(ipsumPath) >= 0 || k.indexOf(loremPath) >= 0; });
             test.ok(filtered.length === 2);
             test.ok(filtered.length === Object.keys(coverage).length);
             test.done();

--- a/test/other/test-summarizer.js
+++ b/test/other/test-summarizer.js
@@ -1,4 +1,6 @@
-var TreeSummarizer = require('../../lib/util/tree-summarizer'),
+var path = require('path'),
+    SEP = path.sep || '/',
+    TreeSummarizer = require('../../lib/util/tree-summarizer'),
     utils = require('../../lib/object-utils'),
     summarizer,
     tree,
@@ -31,9 +33,9 @@ module.exports = {
     },
     "with a few files in a few dirs": {
         setUp: function (cb) {
-            summarizer.addFileCoverageSummary('/tmp/lib/foo.js', s1);
-            summarizer.addFileCoverageSummary('/tmp/lib/bar.js', s2);
-            summarizer.addFileCoverageSummary('/tmp/lib/util/baz.js', s3);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'foo.js'), s1);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'bar.js'), s2);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'util', 'baz.js'), s3);
             tree = summarizer.getTreeSummary();
             cb();
         },
@@ -46,37 +48,37 @@ module.exports = {
                 utilSummary = utils.mergeSummaryObjects(s3),
                 libSummary = utils.mergeSummaryObjects(s1, s2),
                 fullSummary = utils.mergeSummaryObjects(utilSummary, libSummary);
-            test.equal('/tmp/', node.fullPath());
+            test.equal(SEP + 'tmp' + SEP, node.fullPath());
             test.equal('', node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(fullSummary, node.metrics);
             test.ok(node === tree.getNode(''));
             node = tree.root.children[0];
-            test.equal('/tmp/lib/', node.fullPath());
-            test.equal('lib/', node.displayShortName());
+            test.equal(SEP + ['tmp', 'lib'].join(SEP) + SEP, node.fullPath());
+            test.equal('lib' + SEP, node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(libSummary, node.metrics);
             test.deepEqual(s2, node.children[0].metrics);
             test.deepEqual(s1, node.children[1].metrics);
-            test.ok(node === tree.getNode('lib/'));
+            test.ok(node === tree.getNode('lib' + SEP));
             node = tree.root.children[1];
-            test.equal('/tmp/lib/util/', node.fullPath());
-            test.equal('lib/util/', node.displayShortName());
+            test.equal(SEP + ['tmp', 'lib', 'util'].join(SEP) + SEP, node.fullPath());
+            test.equal(['lib', 'util'].join(SEP) + SEP, node.displayShortName());
             test.equal(1, node.children.length);
             test.deepEqual(utilSummary, node.metrics);
             test.deepEqual(s3, node.children[0].metrics);
-            test.ok(node === tree.getNode('lib/util/'));
-            test.ok(tree.getNode('lib/foo.js'));
-            test.ok(tree.getNode('lib/bar.js'));
-            test.ok(tree.getNode('lib/util/baz.js'));
+            test.ok(node === tree.getNode(path.join('lib', 'util') + SEP));
+            test.ok(tree.getNode(path.join('lib', 'foo.js')));
+            test.ok(tree.getNode(path.join('lib', 'bar.js')));
+            test.ok(tree.getNode(path.join('lib', 'util', 'baz.js')));
             test.done();
         }
     },
     "with the same few files organized differently": {
         setUp: function (cb) {
-            summarizer.addFileCoverageSummary('/tmp/lib/main/foo.js', s1);
-            summarizer.addFileCoverageSummary('/tmp/lib/main/bar.js', s2);
-            summarizer.addFileCoverageSummary('/tmp/lib/util/baz.js', s3);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'main', 'foo.js'), s1);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'main', 'bar.js'), s2);
+            summarizer.addFileCoverageSummary(SEP + path.join('tmp', 'lib', 'util', 'baz.js'), s3);
             tree = summarizer.getTreeSummary();
             cb();
         },
@@ -85,37 +87,37 @@ module.exports = {
                 utilSummary = utils.mergeSummaryObjects(s3),
                 libSummary = utils.mergeSummaryObjects(s1, s2),
                 fullSummary = utils.mergeSummaryObjects(utilSummary, libSummary);
-            test.equal('/tmp/lib/', node.fullPath());
+            test.equal(SEP + ['tmp', 'lib'].join(SEP) + SEP, node.fullPath());
             test.equal('', node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(fullSummary, node.metrics);
             test.ok(node === tree.getNode(''));
             node = tree.root.children[0];
-            test.equal('/tmp/lib/main/', node.fullPath());
-            test.equal('main/', node.displayShortName());
+            test.equal(SEP + ['tmp', 'lib', 'main'].join(SEP) + SEP, node.fullPath());
+            test.equal('main' + SEP, node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(libSummary, node.metrics);
             test.deepEqual(s2, node.children[0].metrics);
             test.deepEqual(s1, node.children[1].metrics);
-            test.ok(node === tree.getNode('main/'));
+            test.ok(node === tree.getNode('main' + SEP));
             node = tree.root.children[1];
-            test.equal('/tmp/lib/util/', node.fullPath());
-            test.equal('util/', node.displayShortName());
+            test.equal(SEP + ['tmp', 'lib', 'util'].join(SEP) + SEP, node.fullPath());
+            test.equal('util' + SEP, node.displayShortName());
             test.equal(1, node.children.length);
             test.deepEqual(utilSummary, node.metrics);
             test.deepEqual(s3, node.children[0].metrics);
-            test.ok(node === tree.getNode('util/'));
-            test.ok(tree.getNode('main/foo.js'));
-            test.ok(tree.getNode('main/bar.js'));
-            test.ok(tree.getNode('util/baz.js'));
+            test.ok(node === tree.getNode('util' + SEP));
+            test.ok(tree.getNode(path.join('main', 'foo.js')));
+            test.ok(tree.getNode(path.join('main', 'bar.js')));
+            test.ok(tree.getNode(path.join('util', 'baz.js')));
             test.done();
         }
     },
     "with no room for hoisting": {
         setUp: function (cb) {
-            summarizer.addFileCoverageSummary('/foo.js', s1);
-            summarizer.addFileCoverageSummary('/bar.js', s2);
-            summarizer.addFileCoverageSummary('/util/baz.js', s3);
+            summarizer.addFileCoverageSummary(SEP + 'foo.js', s1);
+            summarizer.addFileCoverageSummary(SEP + 'bar.js', s2);
+            summarizer.addFileCoverageSummary(SEP + path.join('util', 'baz.js'), s3);
             tree = summarizer.getTreeSummary();
             //console.log(JSON.stringify(tree, undefined, 2));
             cb();
@@ -125,29 +127,29 @@ module.exports = {
                 utilSummary = utils.mergeSummaryObjects(s3),
                 libSummary = utils.mergeSummaryObjects(s1, s2),
                 fullSummary = utils.mergeSummaryObjects(utilSummary, libSummary);
-            test.equal('/', node.fullPath());
+            test.equal(SEP, node.fullPath());
             test.equal('', node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(fullSummary, node.metrics);
             test.ok(node === tree.getNode(''));
             node = tree.root.children[0];
-            test.equal('/__root__/', node.fullPath());
-            test.equal('__root__/', node.displayShortName());
+            test.equal(SEP + '__root__' + SEP, node.fullPath());
+            test.equal('__root__' + SEP, node.displayShortName());
             test.equal(2, node.children.length);
             test.deepEqual(libSummary, node.metrics);
             test.deepEqual(s2, node.children[0].metrics);
             test.deepEqual(s1, node.children[1].metrics);
-            test.ok(node === tree.getNode('__root__/'));
+            test.ok(node === tree.getNode('__root__' + SEP));
             node = tree.root.children[1];
-            test.equal('/util/', node.fullPath());
-            test.equal('util/', node.displayShortName());
+            test.equal(SEP + 'util' + SEP, node.fullPath());
+            test.equal('util' + SEP, node.displayShortName());
             test.equal(1, node.children.length);
             test.deepEqual(utilSummary, node.metrics);
             test.deepEqual(s3, node.children[0].metrics);
-            test.ok(node === tree.getNode('util/'));
+            test.ok(node === tree.getNode('util' + SEP));
             test.ok(tree.getNode('foo.js'));
             test.ok(tree.getNode('bar.js'));
-            test.ok(tree.getNode('util/baz.js'));
+            test.ok(tree.getNode(path.join('util', 'baz.js')));
             test.done();
         }
     },
@@ -162,7 +164,7 @@ module.exports = {
 
             blank.statements.pct = blank.lines.pct = blank.branches.pct = blank.functions.pct = 100;
             test.ok(node);
-            test.equal('/', node.fullPath());
+            test.equal(SEP, node.fullPath());
             test.equal('', node.displayShortName());
             test.equal(0, node.children.length);
             test.deepEqual(blank, node.metrics);


### PR DESCRIPTION
So the course of trying to actually add tests for https://github.com/gotwarlost/istanbul/pull/219 I found that I was unable to run the test suite on a Windows machine. This fixes the following issues when running on Windows:

1. The `npm test` command was missing the binary to run the file with, which is necessary for Windows.
2. There were a bunch of tests that used file paths and compared strings to file paths, but they assumed the path separator was a forward slash, though it is a backslash on Windows.
3. Due to a really crappy bug in Node.js on Windows when the process's output is piped (which is the case when calling with `spawn`), output from the child Node.js process will get cut off is the event loop is stopped before all the pending writes has completed. This caused lots of output-checking related tests to fail.