### PR TITLE
Incrementing hits in reports on ignored statements

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -345,6 +345,50 @@
         return ret;
     }
 
+    /**
+     * Creates new file coverage object with incremented hits count
+     * on skipped statements, branches and functions
+     *
+     * @method incrementIgnoredTotals
+     * @static
+     * @param {Object} fileCoverage File coverage object
+     * @return {Object} New file coverage object
+     */
+    function incrementIgnoredTotals(fileCoverage) {
+        // TODO: implementation of extend() function needed
+        // fileCoverage = extend(fileCoverage);
+
+        [
+            {mapKey: 'statementMap', hitsKey: 's'},
+            {mapKey: 'branchMap', hitsKey: 'b'},
+            {mapKey: 'fnMap', hitsKey: 'f'}
+        ].forEach(function (keys) {
+            Object.keys(fileCoverage[keys.mapKey])
+                .forEach(function (key) {
+                    var map = fileCoverage[keys.mapKey][key];
+                    var hits = fileCoverage[keys.hitsKey];
+
+                    if (keys.mapKey === 'branchMap') {
+                        var locations = map.locations;
+
+                        locations.forEach(function (location, index) {
+                            if (hits[key][index] === 0 && location.skip) {
+                                hits[key][index] = 1;
+                            }
+                        });
+
+                        return;
+                    }
+
+                    if (hits[key] === 0 && map.skip) {
+                        hits[key] = 1;
+                    }
+                });
+            });
+
+        return fileCoverage;
+    }
+
     var exportables = {
         addDerivedInfo: addDerivedInfo,
         addDerivedInfoForFile: addDerivedInfoForFile,
@@ -354,7 +398,8 @@
         summarizeCoverage: summarizeCoverage,
         mergeFileCoverage: mergeFileCoverage,
         mergeSummaryObjects: mergeSummaryObjects,
-        toYUICoverage: toYUICoverage
+        toYUICoverage: toYUICoverage,
+        incrementIgnoredTotals: incrementIgnoredTotals
     };
 
     /* istanbul ignore else: windows */

--- a/lib/report/clover.js
+++ b/lib/report/clover.js
@@ -55,6 +55,8 @@ function branchCoverageByLine(fileCoverage) {
 }
 
 function addClassStats(node, fileCoverage, writer) {
+    fileCoverage = utils.incrementIgnoredTotals(fileCoverage);
+
     var metrics = node.metrics,
         branchByLine = branchCoverageByLine(fileCoverage),
         fnMap,

--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -75,6 +75,8 @@ function branchCoverageByLine(fileCoverage) {
 }
 
 function addClassStats(node, fileCoverage, writer, projectRoot) {
+    fileCoverage = utils.incrementIgnoredTotals(fileCoverage);
+
     var metrics = node.metrics,
         branchByLine = branchCoverageByLine(fileCoverage),
         fnMap,

--- a/test/other/test-object-utils.js
+++ b/test/other/test-object-utils.js
@@ -196,6 +196,46 @@ module.exports = {
 
             test.deepEqual(ret, foo);
             test.done();
+        },
+        "increment ignored totals": {
+            setUp: function (cb) {
+                it = {
+                    l: {},
+                    s: {
+                        1: 0
+                    },
+                    b: {
+                        1: [0, 0]
+                    },
+                    f: {
+                        1: 0
+                    },
+                    statementMap: {
+                        1: {skip: true}
+                    },
+                    branchMap: {
+                        1: {
+                            locations: [
+                                {},
+                                {skip: true}
+                            ]
+                        }
+                    },
+                    fnMap: {
+                        1: {skip: true}
+                    }
+                };
+
+                cb();
+            },
+            "should return file coverage object with incremented hits": function (test) {
+                var result = utils.incrementIgnoredTotals(it);
+                test.equal(1, result.s['1']);
+                test.deepEqual([0, 1], result.b['1']);
+                test.equal(1, result.f['1']);
+                test.done();
+            }
         }
     }
 };
+


### PR DESCRIPTION
Here is an new implementation of pull request #211.

By now it doesn't create new coverage object. Is there any implementation of `extend()` that I can use?