### PR TITLE
Fixed parent path for relative paths

### DIFF
--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -97,7 +97,7 @@ TreeSummary.prototype = {
             seen[key] = node;
             nodes.push(node);
             parentPath = path.dirname(key) + SEP;
-            if (parentPath === SEP + SEP) {
+            if (parentPath === SEP + SEP || parentPath === '.' + SEP) {
                 parentPath = SEP + '__root__' + SEP;
             }
             parent = seen[parentPath];
@@ -141,7 +141,7 @@ TreeSummary.prototype = {
             node.name = node.name.substring(1);
         }
         if (parent) {
-            if (parent.name !== '__root__/') {
+            if (parent.name !== '__root__' + SEP) {
                 node.relativeName = node.name.substring(parent.name.length);
             } else {
                 node.relativeName = node.name;


### PR DESCRIPTION
Fixes #156 - broken filenames while using relative paths. The cause for the problem was that a `dirname` of a root in a relative path is `.` not `/` and since `parent.name` wasn't equal to  `__root__/` for files in a root directory, it stripped the first two characters (the length of `./`) off its name.