### PR TITLE
Feature: check tracker variable option.

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -124,7 +124,10 @@
         dot: function (obj, field) { return { type: SYNTAX.MemberExpression.name, computed: false, object: obj, property: field }; },
         subscript: function (obj, sub) { return { type: SYNTAX.MemberExpression.name, computed: true, object: obj, property: sub }; },
         postIncrement: function (obj) { return { type: SYNTAX.UpdateExpression.name, operator: '++', prefix: false, argument: obj }; },
-        sequence: function (one, two) { return { type: SYNTAX.SequenceExpression.name, expressions: [one, two] }; }
+        sequence: function (one, two) { return { type: SYNTAX.SequenceExpression.name, expressions: [one, two] }; },
+        and: function (left, right) { return { type: SYNTAX.LogicalExpression.name, left: left, right: right, operator: '&&' }; },
+        typeOf: function (arg) { return { type: SYNTAX.UnaryExpression.name, argument: arg, operator: 'typeof', prefix: true }; },
+        notEqual: function (left, right) { return { type: SYNTAX.BinaryExpression.name, left: left, right: right, operator: '!=' }; }
     };
 
     function Walker(walkMap, preprocessor, scope, debug) {
@@ -331,6 +334,9 @@
      * @param {Boolean} [options.debug] assist in debugging. Currently, the only effect of
      *      setting this option is a pretty-print of the coverage variable. Defaults to `false`
      * @param {Boolean} [options.walkDebug] assist in debugging of the AST walker used by this class.
+     * @param {Boolean} [options.checkTrackerVar] check if the tracker variable is available
+     *      before incrementing the counter. Useful when a piece of instrumented code is executed
+     *      in a different context. Defaults to `false`
      *
      */
     function Instrumenter(options) {
@@ -342,7 +348,8 @@
             noAutoWrap: false,
             noCompact: false,
             embedSource: false,
-            preserveComments: false
+            preserveComments: false,
+            checkTrackerVar: false
         };
 
         this.walker = new Walker({
@@ -736,14 +743,27 @@
                 sName = this.statementName(node.loc, 1);
             } else {
                 sName = this.statementName(node.loc);
-                incrStatementCount = astgen.statement(
-                    astgen.postIncrement(
-                        astgen.subscript(
-                            astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
-                            astgen.stringLiteral(sName)
-                        )
+                incrStatementCount = astgen.postIncrement(
+                    astgen.subscript(
+                        astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
+                        astgen.stringLiteral(sName)
                     )
                 );
+
+                if (this.opts.checkTrackerVar) {
+                    incrStatementCount = astgen.statement(
+                        astgen.and(
+                            astgen.notEqual(
+                                astgen.typeOf(astgen.variable(this.currentState.trackerVar)),
+                                astgen.stringLiteral('undefined')
+                            ),
+                            incrStatementCount
+                        )
+                    );
+                } else {
+                    incrStatementCount = astgen.statement(incrStatementCount);
+                }
+
                 this.splice(incrStatementCount, node, walker);
             }
         },
@@ -768,6 +788,7 @@
             var id,
                 body = node.body,
                 blockBody = body.body,
+                incrFunctionCount,
                 popped;
 
             this.maybeSkipNode(node, 'next');
@@ -780,16 +801,30 @@
             if (blockBody.length > 0 && this.isUseStrictExpression(blockBody[0])) {
                 popped = blockBody.shift();
             }
-            blockBody.unshift(
-                astgen.statement(
-                    astgen.postIncrement(
-                        astgen.subscript(
-                            astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('f')),
-                            astgen.stringLiteral(id)
-                        )
-                    )
+
+            incrFunctionCount = astgen.postIncrement(
+                astgen.subscript(
+                    astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('f')),
+                    astgen.stringLiteral(id)
                 )
             );
+
+            if (this.opts.checkTrackerVar) {
+                incrFunctionCount = astgen.statement(
+                    astgen.and(
+                        astgen.notEqual(
+                            astgen.typeOf(astgen.variable(this.currentState.trackerVar)),
+                            astgen.stringLiteral('undefined')
+                        ),
+                        incrFunctionCount
+                    )
+                );
+            } else {
+                incrFunctionCount = astgen.statement(incrFunctionCount);
+            }
+
+            blockBody.unshift(incrFunctionCount);
+
             if (popped) {
                 blockBody.unshift(popped);
             }
@@ -824,6 +859,17 @@
                 ),
                 down
             );
+
+            if (this.opts.checkTrackerVar) {
+                ret = astgen.and(
+                    astgen.notEqual(
+                        astgen.typeOf(astgen.variable(this.currentState.trackerVar)),
+                        astgen.stringLiteral('undefined')
+                    ),
+                    ret
+                );
+            }
+
             return ret;
         },
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -89,7 +89,8 @@ function setup(file, codeArray, opts) {
             noAutoWrap: opts.noAutoWrap,
             coverageVariable: coverageVariable,
             embedSource: ps,
-            preserveComments: pc
+            preserveComments: pc,
+            checkTrackerVar: opts.checkTrackerVar
         }),
         args = [ codeArray.join("\n")],
         callback = function (err, generated) {

--- a/test/instrumentation/test-statement.js
+++ b/test/instrumentation/test-statement.js
@@ -203,6 +203,21 @@ module.exports = {
             verifier.verify(test, [ 1 ], "undef", { lines: { 2: 1, 4: 1 }, branches: { 1: [ 0, 1 ]}, functions: {}, statements: { 1: 1, 2: 1 } });
             test.done();
         }
+    },
+    "with tracker variable check": {
+        setUp: function (cb) {
+            code = [
+                'var foo = function(x) {',
+                'return x > 0 ? ++x : --x;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code, { checkTrackerVar: true });
+            cb();
+        },
+        "should check if tracker variable exists before incrementing the counters": function (test) {
+            test.ok(verifier.generatedCode.match(/typeof\s__cov_(?:[\w$_]+)!='undefined'&&[\w$_]+\.[s|f|b]/));
+            test.done();
+        }
     }
 };
 


### PR DESCRIPTION
This feature adds a `checkTrackerVar` option to the Instrumenter. When enabled, it that will wrap every function/statement/branch counter statement with a check for tracker variable existence. This is useful when a part of the instrumented code is executed in a different context (e.g. in a vm or an iframe).
By default this option is set to `false`.