### PR TITLE
Sample code triggers error

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ All the features of istanbul can be accessed as a library.
 #### Instrument code
 
 ```javascript
-    var instrumenter = new require('istanbul').Instrumenter();
+    var istanbul = require('istanbul'),
+      instrumenter = new istanbul.Instrumenter();
     
     var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { return 42; }',
         'filename.js');

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -291,8 +291,10 @@
      * Usage on nodejs
      * ---------------
      *
-     *      var instrumenter = new require('istanbul').Instrumenter(),
+     *      var istanbul = require('istanbul'),
+     *          instrumenter = new istanbul.Instrumenter(),
      *          changed = instrumenter.instrumentSync('function meaningOfLife() { return 42; }', 'filename.js');
+     *
      *
      * Usage in a browser
      * ------------------


### PR DESCRIPTION
This sample code:

``` javascript
var instrumenter = new require('istanbul').Instrumenter();
var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { return 42; }', 'filename.js');
```

Triggers the error:
```TypeError: Cannot call method 'instrumentSync' of undefined```

Can be solved by separating out the require on it's own.