### PR TITLE
Add explicit license tag to the package meta-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Yet another JS code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests. Supports all JS coverage use cases including unit tests, server side functional tests and browser tests. Built for scale",
     "keywords": [ "coverage", "code coverage", "JS code coverage", "JS coverage" ],
     "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
+    "license" : "BSD-3-Clause",
     "contributors": [
         "Reid Burke <me@reidburke.com>",
         "Martin Cooper <mfncooper@gmail.com>",


### PR DESCRIPTION
This tag allows automated tools to detect a correct license for the package.
