### PR TITLE
Add per-file / config-based coverage enforcement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,5 @@ after_script:
   - if [[ `node --version` == *v0.10* ]]; then cat ./build/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js; fi
 
 before_install:
-  - if [[ `node --version` == *v0.8* ]]; then npm install -g npm; fi
-
-
+  # Node v0.8 needs specific NPM version: https://github.com/npm/npm/issues/6246#issuecomment-57911124
+  - if [[ `node --version` == *v0.8* ]]; then npm install -g npm@1.4.28; fi

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Usage: istanbul help config | <command>
 Available commands are:
 
       check-coverage
-              checks overall coverage against thresholds from coverage JSON
-              files. Exits 1 if thresholds are not met, 0 otherwise
+              checks overall/per-file coverage against thresholds from coverage
+              JSON files. Exits 1 if thresholds are not met, 0 otherwise
 
 
       cover   transparently adds coverage information to a node command. Saves
@@ -109,8 +109,8 @@ The `cover` command can be used to get a coverage object and reports for any arb
 node script. By default, coverage information is written under `./coverage` - this
 can be changed using command-line options.
 
-The `cover` command can also be passed an optional `--handle-sigint` flag to 
-enable writing reports when a user triggers a manual SIGINT of the process that is 
+The `cover` command can also be passed an optional `--handle-sigint` flag to
+enable writing reports when a user triggers a manual SIGINT of the process that is
 being covered. This can be useful when you are generating coverage for a long lived process.
 
 #### The `test` command
@@ -123,13 +123,13 @@ set the `npm_config_coverage` variable.
 
 #### The `instrument` command
 
-Instruments a single JS file or an entire directory tree and produces an output 
-directory tree with instrumented code. This should not be required for running node 
+Instruments a single JS file or an entire directory tree and produces an output
+directory tree with instrumented code. This should not be required for running node
 unit tests but is useful for tests to be run on the browser.
 
 #### The `report` command
 
-Writes reports using `coverage*.json` files as the source of coverage information. 
+Writes reports using `coverage*.json` files as the source of coverage information.
 Reports are available in multiple formats and can be individually configured
 using the istanbul config file. See `istanbul help report` for more details.
 
@@ -151,12 +151,12 @@ See [ignoring-code-for-coverage.md](ignoring-code-for-coverage.md) for the spec.
 ### API
 
 All the features of istanbul can be accessed as a library.
- 
+
 #### Instrument code
 
 ```javascript
     var instrumenter = new require('istanbul').Instrumenter();
-    
+
     var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { return 42; }',
         'filename.js');
 ```
@@ -164,7 +164,7 @@ All the features of istanbul can be accessed as a library.
 #### Generate reports given a bunch of coverage JSON objects
 
 ```javascript
-    var istanbul = require('istanbul'), 
+    var istanbul = require('istanbul'),
         collector = new istanbul.Collector(),
         reporter = new istanbul.Reporter(),
         sync = false;
@@ -219,6 +219,6 @@ The following third-party libraries are used by this module:
 
 ### Why the funky name?
 
-Since all the good ones are taken. Comes from the loose association of ideas across 
+Since all the good ones are taken. Comes from the loose association of ideas across
 coverage, carpet-area coverage, the country that makes good carpets and so on...
 

--- a/lib/command/check-coverage.js
+++ b/lib/command/check-coverage.js
@@ -11,10 +11,29 @@ var nopt = require('nopt'),
     util = require('util'),
     utils = require('../object-utils'),
     filesFor = require('../util/file-matcher').filesFor,
-    Command = require('./index');
+    Command = require('./index'),
+    configuration = require('../config');
 
 function CheckCoverageCommand() {
     Command.call(this);
+}
+
+function removeFiles(covObj, root, files) {
+    var filesObj = {},
+        obj = {};
+
+    // Create lookup table.
+    files.forEach(function (file) {
+        filesObj[path.join(root, file)] = true;
+    });
+
+    Object.keys(covObj).forEach(function (key) {
+        if (filesObj[key] !== true) {
+            obj[key] = covObj[key];
+        }
+    });
+
+    return obj;
 }
 
 CheckCoverageCommand.TYPE = 'check-coverage';
@@ -22,16 +41,16 @@ util.inherits(CheckCoverageCommand, Command);
 
 Command.mix(CheckCoverageCommand, {
     synopsis: function () {
-        return "checks overall coverage against thresholds from coverage JSON files. Exits 1 if thresholds are not met, 0 otherwise";
+        return "checks overall/per-file coverage against thresholds from coverage JSON files. Exits 1 if thresholds are not met, 0 otherwise";
     },
 
     usage: function () {
         console.error('\nUsage: ' + this.toolName() + ' ' + this.type() + ' <options> [<include-pattern>]\n\nOptions are:\n\n' +
             [
-                formatOption('--statements <threshold>', 'statement coverage threshold'),
-                formatOption('--functions <threshold>', 'function coverage threshold'),
-                formatOption('--branches <threshold>', 'branch coverage threshold'),
-                formatOption('--lines <threshold>', 'line coverage threshold')
+                formatOption('--statements <threshold>', 'global statement coverage threshold'),
+                formatOption('--functions <threshold>', 'global function coverage threshold'),
+                formatOption('--branches <threshold>', 'global branch coverage threshold'),
+                formatOption('--lines <threshold>', 'global line coverage threshold')
             ].join('\n\n') + '\n');
 
         console.error('\n\n');
@@ -40,6 +59,7 @@ Command.mix(CheckCoverageCommand, {
         console.error('When a threshold is specified as a negative number it represents the maximum number of uncovered entities allowed.\n');
         console.error('For example, --statements 90 implies minimum statement coverage is 90%.');
         console.error('             --statements -10 implies that no more than 10 uncovered statements are allowed\n');
+        console.error('Per-file thresholds can be specified via a configuration file.\n');
         console.error('<include-pattern> is a fileset pattern that can be used to select one or more coverage files ' +
             'for merge. This defaults to "**/coverage*.json"');
 
@@ -48,16 +68,28 @@ Command.mix(CheckCoverageCommand, {
 
     run: function (args, callback) {
 
-        var config = {
+        var template = {
+                config: path,
                 root: path,
-                dir: path,
                 statements: Number,
                 lines: Number,
                 branches: Number,
                 functions: Number,
                 verbose: Boolean
             },
-            opts = nopt(config, { v : '--verbose' }, args, 0),
+            opts = nopt(template, { v : '--verbose' }, args, 0),
+            // Translate to config opts.
+            config = configuration.loadFile(opts.config, {
+                verbose: opts.verbose,
+                check: {
+                    global: {
+                        statements: opts.statements,
+                        lines: opts.lines,
+                        branches: opts.branches,
+                        functions: opts.functions
+                    }
+                }
+            }),
             includePattern = '**/coverage*.json',
             root,
             collector = new Collector(),
@@ -74,37 +106,70 @@ Command.mix(CheckCoverageCommand, {
         }, function (err, files) {
             if (err) { throw err; }
             files.forEach(function (file) {
-                var coverageObject =  JSON.parse(fs.readFileSync(file, 'utf8'));
+                var coverageObject = JSON.parse(fs.readFileSync(file, 'utf8'));
                 collector.add(coverageObject);
             });
             var thresholds = {
-                statements: opts.statements || 0,
-                branches: opts.branches || 0,
-                lines: opts.lines || 0,
-                functions: opts.functions || 0
+                global: {
+                    statements: config.check.global.statements || 0,
+                    branches: config.check.global.branches || 0,
+                    lines: config.check.global.lines || 0,
+                    functions: config.check.global.functions || 0,
+                    excludes: config.check.global.excludes || []
+                },
+                each: {
+                    statements: config.check.each.statements || 0,
+                    branches: config.check.each.branches || 0,
+                    lines: config.check.each.lines || 0,
+                    functions: config.check.each.functions || 0,
+                    excludes: config.check.each.excludes || []
+                }
             },
-                actuals = utils.summarizeCoverage(collector.getFinalCoverage());
+                rawCoverage = collector.getFinalCoverage(),
+                globalResults = utils.summarizeCoverage(removeFiles(rawCoverage, root, thresholds.global.excludes)),
+                eachResults = removeFiles(rawCoverage, root, thresholds.each.excludes);
 
-            if (opts.verbose) {
+            // Summarize per-file results and mutate original results.
+            Object.keys(eachResults).forEach(function (key) {
+                eachResults[key] = utils.summarizeFileCoverage(eachResults[key]);
+            });
+
+            if (config.verbose) {
                 console.log('Compare actuals against thresholds');
-                console.log(JSON.stringify({ actuals: actuals, thresholds: thresholds }, undefined, 4));
+                console.log(JSON.stringify({ global: globalResults, each: eachResults, thresholds: thresholds }, undefined, 4));
             }
 
-            Object.keys(thresholds).forEach(function (key) {
-                var actual = actuals[key].pct,
-                    actualUncovered = actuals[key].total - actuals[key].covered,
-                    threshold = thresholds[key];
+            function check(name, thresholds, actuals) {
+                [
+                    "statements",
+                    "branches",
+                    "lines",
+                    "functions"
+                ].forEach(function (key) {
+                    var actual = actuals[key].pct,
+                        actualUncovered = actuals[key].total - actuals[key].covered,
+                        threshold = thresholds[key];
 
-                if (threshold < 0) {
-                    if (threshold * -1 < actualUncovered) {
-                        errors.push('ERROR: Uncovered count for ' + key + ' (' + actualUncovered + ') exceeds threshold (' + -1 * threshold + ')');
+                    if (threshold < 0) {
+                        if (threshold * -1 < actualUncovered) {
+                            errors.push('ERROR: Uncovered count for ' + key + ' (' + actualUncovered +
+                                ') exceeds ' + name + ' threshold (' + -1 * threshold + ')');
+                        }
+                    } else {
+                        if (actual < threshold) {
+                            errors.push('ERROR: Coverage for ' + key + ' (' + actual +
+                                '%) does not meet ' + name + ' threshold (' + threshold + '%)');
+                        }
                     }
-                } else {
-                    if (actual < threshold) {
-                        errors.push('ERROR: Coverage for ' + key + ' (' + actual + '%) does not meet threshold (' + threshold + '%)');
-                    }
-                }
+                });
+            }
+
+            check("global", thresholds.global, globalResults);
+
+            Object.keys(eachResults).forEach(function (key) {
+                check("per-file" + " (" + key + ") ", thresholds.each, eachResults[key]);
             });
+
             return callback(errors.length === 0 ? null : errors.join("\n"));
         });
     }

--- a/lib/command/help.js
+++ b/lib/command/help.js
@@ -21,8 +21,8 @@ function showConfigHelp(toolName) {
             'customize its location per command. The alternate config file can be in YAML, JSON or node.js ' +
             '(exporting the config object).'));
     console.error('\n' +
-        formatPara('The config file currently has three sections for instrumentation, reporting and hooks. ' +
-            'Note that certain commands (like `cover`) use information from multiple sections.'));
+        formatPara('The config file currently has four sections for instrumentation, reporting, hooks, ' +
+            'and checking. Note that certain commands (like `cover`) use information from multiple sections.'));
     console.error('\n' +
         formatPara('Keys in the config file usually correspond to command line parameters with the same name. ' +
             'The verbose option for every command shows you the exact configuration used. See the api ' +
@@ -40,6 +40,10 @@ function showConfigHelp(toolName) {
     console.error('\n' +
         formatPara('The `reportConfig` section allows you to configure each report format independently ' +
             'and has no command-line equivalent either.'));
+    console.error('\n' +
+        formatPara('The `check` section configures minimum threshold enforcement for coverage results. ' +
+            '`global` applies to all files together and `each` on a per-file basis. A list of files can ' +
+            'be excluded from enforcement relative to root via the `exclude` property.'));
     console.error('');
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -35,6 +35,22 @@ function defaultConfig() {
             'hook-run-in-context': false,
             'post-require-hook': null,
             'handle-sigint': false
+        },
+        check: {
+            global: {
+                statements: 0,
+                lines: 0,
+                branches: 0,
+                functions: 0,
+                excludes: [] // Currently list of files (root + path). For future, extend to patterns.
+            },
+            each: {
+                statements: 0,
+                lines: 0,
+                branches: 0,
+                functions: 0,
+                excludes: []
+            }
         }
     };
     ret.reporting.watermarks = defaults.watermarks();
@@ -350,7 +366,7 @@ function Configuration(obj, overrides) {
     this.instrumentation = new InstrumentOptions(config.instrumentation);
     this.reporting = new ReportingOptions(config.reporting);
     this.hooks = new HookOptions(config.hooks);
-    //this.thresholds = new ThresholdOptions(config.thresholds);
+    this.check = config.check; // Pass raw config sub-object.
 }
 
 /**

--- a/test/cli-helper.js
+++ b/test/cli-helper.js
@@ -36,13 +36,13 @@ var path = require('path'),
  *  3. In the child process,
  *      a. hooks the module loader to set up coverage for our library code
  *      b. Ensures that the `hook` module is not loaded until all this happens
-  *         so that the hook module sees _our_ module loader hook as the original
-  *         loader. This ensures that our hook will be used to instrument this
-  *         library's code. Note that the hook set up by the `cover` command that
-  *         is executed only instruments the modules of the sample test library.
-  *     c. Calls Module.runMain on the command that it was asked to invoke
-  *     d. Sets up an exit handler to write the coverage information for our
-  *         library calls
+ *         so that the hook module sees _our_ module loader hook as the original
+ *         loader. This ensures that our hook will be used to instrument this
+ *         library's code. Note that the hook set up by the `cover` command that
+ *         is executed only instruments the modules of the sample test library.
+ *      c. Calls Module.runMain on the command that it was asked to invoke
+ *      d. Sets up an exit handler to write the coverage information for our
+ *         library calls
  *   4. The exit handler is also set up in special ways because in order to
  *      instrument the `cover` command's exit handler, our exit handler has
  *      to be added later so as to be able to track coverage for the cover

--- a/test/cli/sample-project/config-check-each.istanbul.yml
+++ b/test/cli/sample-project/config-check-each.istanbul.yml
@@ -1,0 +1,8 @@
+check:
+  each:
+    statements: 72
+    functions: 50
+    branches: 72
+    lines: 72
+    excludes:
+        - lib/bar.js # 40, 0, 40, 0

--- a/test/cli/sample-project/config-check-global.istanbul.yml
+++ b/test/cli/sample-project/config-check-global.istanbul.yml
@@ -1,0 +1,12 @@
+check:
+  global:
+    statements: 72
+    functions: 50
+    branches: 72
+    lines: 72
+    # Example: Could exclude all files covered (would pass checks and fail the tests).
+    # excludes:
+    #     - lib/foo.js
+    #     - vendor/dummy_vendor_lib.js
+    #     - lib/util/generate-names.js
+    #     - lib/bar.js

--- a/test/cli/sample-project/config-check-mixed.istanbul.yml
+++ b/test/cli/sample-project/config-check-mixed.istanbul.yml
@@ -1,0 +1,13 @@
+check:
+  global:
+    statements: 80
+    functions: 80
+    branches: 40
+    lines: 40
+  each:
+    statements: 72
+    functions: 50
+    branches: 72
+    lines: 72
+    excludes:
+        - lib/bar.js # 40, 0, 40, 0

--- a/test/cli/sample-project/config.istanbul.yml
+++ b/test/cli/sample-project/config.istanbul.yml
@@ -6,4 +6,3 @@ reporting:
   report-config:
     cobertura:
       file: 'foo.xml'
-

--- a/test/cli/test-check-coverage-command.js
+++ b/test/cli/test-check-coverage-command.js
@@ -25,73 +25,148 @@ module.exports = {
         rimraf.sync(OUTPUT_DIR);
         cb();
     },
-    "should fail on inadequate statement coverage": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--statements', '72' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Coverage for statements/));
-            test.done();
-        });
+    "Global coverage": {
+        "should fail on inadequate statement coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--statements', '72' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for statements .* global/));
+                test.done();
+            });
+        },
+        "should fail on inadequate branch coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--branches', '72' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for branches .* global/));
+                test.done();
+            });
+        },
+        "should fail on inadequate function coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--functions', '72' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for functions .* global/));
+                test.done();
+            });
+        },
+        "should fail on inadequate line coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--lines', '72' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for lines .* global/));
+                test.done();
+            });
+        },
+        "should fail with multiple reasons when multiple thresholds violated": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--statements=72', '--functions=50', '--branches=72', '--lines=72' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for lines .* global/));
+                test.ok(results.grepError(/Coverage for statements .* global/));
+                test.ok(results.grepError(/Coverage for branches .* global/));
+                test.ok(!results.grepError(/Coverage for functions .* global/));
+                test.done();
+            });
+        },
+        "should fail with multiple reasons from configuration file": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            // YML equivalent to: '--statements=72', '--functions=50', '--branches=72', '--lines=72'
+            run([ '--config', 'config-check-global.istanbul.yml' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for lines .* global/));
+                test.ok(results.grepError(/Coverage for statements .* global/));
+                test.ok(results.grepError(/Coverage for branches .* global/));
+                test.ok(!results.grepError(/Coverage for functions .* global/));
+                test.done();
+            });
+        },
+        "should fail with multiple reasons from configuration file and command line": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            // YML equivalent to: '--statements=72', '--functions=50', '--branches=72', '--lines=72'
+            run([ '--statements=10', '--config', 'config-check-global.istanbul.yml' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Coverage for lines .* global/));
+                test.ok(!results.grepError(/Coverage for statements .* global/));
+                test.ok(results.grepError(/Coverage for branches .* global/));
+                test.ok(!results.grepError(/Coverage for functions .* global/));
+                test.done();
+            });
+        },
+        "should fail with multiple reasons when multiple thresholds violated with negative thresholds": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--statements=-3', '--functions=-10', '--branches=-1', '--lines=-3' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/Uncovered count for lines .* global/));
+                test.ok(results.grepError(/Uncovered count for statements .* global/));
+                test.ok(results.grepError(/Uncovered count for branches .* global/));
+                test.ok(!results.grepError(/Uncovered count for functions .* global/));
+                test.done();
+            });
+        },
+        "should pass with multiple reasons when all thresholds in check": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--statements=60', '--functions=50', '--branches=50', '--lines=60', '-v' ], function (results) {
+                test.ok(results.succeeded());
+                test.ok(!results.grepOutput(/\\"actuals\\"/), "Verbose message not printed as expected");
+                test.done();
+            });
+        },
+        "should succeed with any threshold when no coverage found": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--statements', '72', '**/foobar.json' ], function (results) {
+                test.ok(results.succeeded());
+                test.done();
+            });
+        }
     },
-    "should fail on inadequate branch coverage": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--branches', '72' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Coverage for branches/));
-            test.done();
-        });
-    },
-    "should fail on inadequate function coverage": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--functions', '72' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Coverage for functions/));
-            test.done();
-        });
-    },
-    "should fail on inadequate line coverage": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--lines', '72' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Coverage for lines/));
-            test.done();
-        });
-    },
-    "should fail with multiple reasons when multiple thresholds violated": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--statements=72', '--functions=50', '--branches=72', '--lines=72' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Coverage for lines/));
-            test.ok(results.grepError(/Coverage for statements/));
-            test.ok(results.grepError(/Coverage for branches/));
-            test.ok(!results.grepError(/Coverage for functions/));
-            test.done();
-        });
-    },
-    "should fail with multiple reasons when multiple thresholds violated with negative thresholds": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--statements=-3', '--functions=-10', '--branches=-1', '--lines=-3' ], function (results) {
-            test.ok(!results.succeeded());
-            test.ok(results.grepError(/Uncovered count for lines/));
-            test.ok(results.grepError(/Uncovered count for statements/));
-            test.ok(results.grepError(/Uncovered count for branches/));
-            test.ok(!results.grepError(/Uncovered count for functions/));
-            test.done();
-        });
-    },
-    "should pass with multiple reasons when all thresholds in check": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--statements=60', '--functions=50', '--branches=50', '--lines=60', '-v' ], function (results) {
-            test.ok(results.succeeded());
-            test.ok(!results.grepOutput(/\\"actuals\\"/), "Verbose message not printed as expected");
-            test.done();
-        });
-    },
-    "should succeed with any threshold when no coverage found": function (test) {
-        test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-        run([ '--statements', '72', '**/foobar.json' ], function (results) {
-            test.ok(results.succeeded());
-            test.done();
-        });
+    "Per-file coverage": {
+        "should fail on inadequate statement and line coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--config', 'config-check-each.istanbul.yml' ], function (results) {
+                // vendor/dummy_vendor_lib.js (statements 66.67% vs. 72%)
+                // vendor/dummy_vendor_lib.js (lines 66.67% vs. 72%)
+                test.ok(!results.succeeded());
+                test.ok(!results.grepError(/Coverage for lines .* global/));
+                test.ok(results.grepError(/Coverage for lines .* per-file/));
+                test.ok(results.grepError(/Coverage for statements .* per-file/));
+                test.ok(!results.grepError(/Coverage for branches .* per-file/));
+                test.ok(!results.grepError(/Coverage for functions .* per-file/));
+                test.ok(results.grepError(/dummy_vendor_lib\.js/));
+                test.ok(!results.grepError(/foo\.js/));
+                test.ok(!results.grepError(/foo\.js/));
+                test.done();
+            });
+        },
+        "should fail on inadequate mixed global args / each coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--branches=100', '--functions=100', '--config', 'config-check-each.istanbul.yml' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(!results.grepError(/Coverage for lines .* global/));
+                test.ok(!results.grepError(/Coverage for statements .* global/));
+                test.ok(results.grepError(/Coverage for branches .* global/));
+                test.ok(results.grepError(/Coverage for functions .* global/));
+                test.ok(results.grepError(/Coverage for lines .* per-file/));
+                test.ok(results.grepError(/Coverage for statements .* per-file/));
+                test.ok(!results.grepError(/Coverage for branches .* per-file/));
+                test.ok(!results.grepError(/Coverage for functions .* per-file/));
+                test.done();
+            });
+        },
+        "should fail on inadequate mixed global / each configured coverage": function (test) {
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            run([ '--config', 'config-check-mixed.istanbul.yml' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(!results.grepError(/Coverage for lines .* global/));
+                test.ok(results.grepError(/Coverage for statements .* global/));
+                test.ok(!results.grepError(/Coverage for branches .* global/));
+                test.ok(results.grepError(/Coverage for functions .* global/));
+                test.ok(results.grepError(/Coverage for lines .* per-file/));
+                test.ok(results.grepError(/Coverage for statements .* per-file/));
+                test.ok(!results.grepError(/Coverage for branches .* per-file/));
+                test.ok(!results.grepError(/Coverage for functions .* per-file/));
+                test.done();
+            });
+        }
     }
 };


### PR DESCRIPTION
This PR implements https://github.com/gotwarlost/istanbul/issues/30 and is based on the good work from @BryanDonovan in closed PR https://github.com/gotwarlost/istanbul/pull/91 with the following items:
- Adds a `check` config parameter with `check.global` for existing command line coverage checking flags.
- Adds `check.each` for per-file coverage (only from config file).
- Adds `excludes` for an array of files (relative to root) to exclude from coverage enforcement for `global` and `each`.
- Fixes Travis CI for Node `v0.8.x`. (It was bugging me along the way).
- Updates help strings to reflect changes.
- Adds unit tests for mixed global command line / config settings and per-file config settings.

Stuff that is not in this PR / for the future:
- Pattern matching configuration params like `patterns-global` and `patterns-each` per my original comment in https://github.com/gotwarlost/istanbul/issues/30#issuecomment-58766089

I hope this is close enough to what we're looking for to give us a path forward with enough flexibility to get everyone on board. I'm happy to tweak this PR if anyone has any specific concerns.

This is a different approach than existing open PR https://github.com/gotwarlost/istanbul/pull/241, which instead adds a new `check-cover-*` command from scratch.

/cc @gotwarlost @geekdave
