### PR TITLE
Add option to include pid in coverage filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,40 @@ All the features of istanbul can be accessed as a library.
 For the gory details consult the [public API](http://gotwarlost.github.com/istanbul/public/apidocs/index.html)
 
 
+### Multiple Process Usage
+
+Istanbul can be used in a multiple process environment by running each process
+with Istanbul, writing a unique coverage file for each process, and combining
+the results when generating reports. The method used to perform this will
+depend on the process forking API used. For example when using the
+[cluster module](http://nodejs.org/api/cluster.html) you must setup the master
+to start child processes with Istanbul coverage, disable reporting, and output
+coverage files that include the PID in the filename.  Before each run you may
+need to clear out the coverage data directory.
+
+```javascript
+    if(cluster.isMaster) {
+        // setup cluster if running with istanbul coverage
+        if(process.env.running_under_istanbul) {
+            // use coverage for forked process
+            // disabled reporting and output for child process
+            // enable pid in child process coverage filename
+            cluster.setupMaster({
+                exec: './node_modules/.bin/istanbul',
+                args: [
+                    'cover', '--report', 'none', '--print', 'none', '--include-pid',
+                    process.argv[1], '--'].concat(process.argv.slice(2))
+            });
+        }
+        // ...
+        // ... cluster.fork();
+        // ...
+    } else {
+        // ... worker code
+    }
+```
+
+
 ### License
 
 istanbul is licensed under the [BSD License](http://github.com/gotwarlost/istanbul/raw/master/LICENSE).

--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -34,7 +34,8 @@ function usage(arg0, command) {
             formatOption('--print <type>', 'type of report to print to console, one of summary (default), detail, both or none'),
             formatOption('--verbose, -v', 'verbose mode'),
             formatOption('--[no-]preserve-comments', 'remove / preserve comments in the output, defaults to false'),
-            formatOption('--include-all-sources', 'instrument all unused sources after running tests, defaults to false')
+            formatOption('--include-all-sources', 'instrument all unused sources after running tests, defaults to false'),
+            formatOption('--[no-]include-pid', 'include PID in output coverage filename')
         ].join('\n\n') + '\n');
     console.error('\n');
 }
@@ -56,7 +57,8 @@ function run(args, commandName, enableHooks, callback) {
             'post-require-hook': String,
             'preserve-comments': Boolean,
             'include-all-sources': Boolean,
-            'preload-sources': Boolean
+            'preload-sources': Boolean,
+            'include-pid': Boolean
         },
         opts = nopt(template, { v : '--verbose' }, args, 0),
         overrides = {
@@ -66,7 +68,8 @@ function run(args, commandName, enableHooks, callback) {
                 'default-excludes': opts['default-excludes'],
                 excludes: opts.x,
                 'include-all-sources': opts['include-all-sources'],
-                'preload-sources': opts['preload-sources']
+                'preload-sources': opts['preload-sources'],
+                'include-pid': opts['include-pid']
             },
             reporting: {
                 reports: opts.report,
@@ -83,6 +86,7 @@ function run(args, commandName, enableHooks, callback) {
         verbose = config.verbose,
         cmdAndArgs = opts.argv.remain,
         preserveComments = opts['preserve-comments'],
+        includePid = opts['include-pid'],
         cmd,
         cmdArgs,
         reportingDir,
@@ -195,7 +199,8 @@ function run(args, commandName, enableHooks, callback) {
                 }
 
                 process.once('exit', function () {
-                    var file = path.resolve(reportingDir, 'coverage.json'),
+                    var pidExt = includePid ? ('-' + process.pid) : '',
+                        file = path.resolve(reportingDir, 'coverage' + pidExt + '.json'),
                         collector,
                         cov;
                     if (typeof global[coverageVar] === 'undefined' || Object.keys(global[coverageVar]).length === 0) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,8 @@ function defaultConfig(includeBackCompatAttrs) {
             'complete-copy': false,
             'save-baseline': false,
             'baseline-file': './coverage/coverage-baseline.json',
-            'include-all-sources': false
+            'include-all-sources': false,
+            'include-pid': false
         },
         reporting: {
             print: 'summary',
@@ -174,13 +175,18 @@ function InstrumentOptions(config) {
  * @method baselineFile
  * @return {String} the name of the baseline coverage file.
  */
+/**
+ * returns if the coverage filename should include the PID. Used by the  `instrument` command.
+ * @method includePid
+ * @return {Boolean} true to include pid in coverage filename.
+ */
 
 
 addMethods(InstrumentOptions,
     'defaultExcludes', 'completeCopy',
     'embedSource', 'variable', 'compact', 'preserveComments',
     'saveBaseline', 'baselineFile',
-    'includeAllSources');
+    'includeAllSources', 'includePid');
 
 /**
  * returns the root directory used by istanbul which is typically the root of the

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
         "nodeunit": "0.9.x",
         "jshint": "2.5.x",
         "requirejs": "2.x",
-        "coveralls": "2.x"
+        "coveralls": "2.x",
+        "glob": "4.4.x"
     }
 }
 

--- a/test/cli/test-include-pid.js
+++ b/test/cli/test-include-pid.js
@@ -1,0 +1,76 @@
+/*jslint nomen: true */
+var path = require('path'),
+    fs = require('fs'),
+    glob = require('glob'),
+    rimraf = require('rimraf'),
+    mkdirp = require('mkdirp'),
+    COMMAND = 'cover',
+    DIR = path.resolve(__dirname, 'sample-project'),
+    OUTPUT_DIR = path.resolve(DIR, 'coverage'),
+    helper = require('../cli-helper'),
+    existsSync = fs.existsSync || path.existsSync,
+    run = helper.runCommand.bind(null, COMMAND);
+
+module.exports = {
+    setUp: function (cb) {
+        rimraf.sync(OUTPUT_DIR);
+        mkdirp.sync(OUTPUT_DIR);
+        helper.resetOpts();
+        cb();
+    },
+    tearDown: function (cb) {
+        rimraf.sync(OUTPUT_DIR);
+        cb();
+    },
+    "should have no pid by default": function (test) {
+        helper.setOpts({ lazyHook : true });
+        run([ 'test/run.js', '-v'], function (results) {
+            test.ok(results.succeeded());
+            test.ok(results.grepError(/Module load hook:/));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov.info')));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            var coverage = JSON.parse(fs.readFileSync(path.resolve(OUTPUT_DIR, 'coverage.json'), 'utf8')),
+                filtered;
+            filtered = Object.keys(coverage).filter(function (k) { return k.match(/foo/) || k.match(/bar/); });
+            test.ok(filtered.length === 2);
+            test.done();
+        });
+    },
+    "should have no pid if requested": function (test) {
+        helper.setOpts({ lazyHook : true });
+        run([ 'test/run.js', '-v', '--no-include-pid'], function (results) {
+            test.ok(results.succeeded());
+            test.ok(results.grepError(/Module load hook:/));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov.info')));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
+            var coverage = JSON.parse(fs.readFileSync(path.resolve(OUTPUT_DIR, 'coverage.json'), 'utf8')),
+                filtered;
+            filtered = Object.keys(coverage).filter(function (k) { return k.match(/foo/) || k.match(/bar/); });
+            test.ok(filtered.length === 2);
+            test.done();
+        });
+    },
+    "should have pid if requested": function (test) {
+        helper.setOpts({ lazyHook : true });
+        run([ 'test/run.js', '-v', '--include-pid'], function (results) {
+            test.ok(results.succeeded());
+            test.ok(results.grepError(/Module load hook:/));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov.info')));
+            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));
+            glob(path.resolve(OUTPUT_DIR, 'coverage-*.json'), function(err, matches) {
+              test.ifError(err, 'pid coverage file glob error');
+              test.ok(matches.length !== 0, 'pid coverage file not found');
+              matches.forEach(function(file) {
+                test.ok(existsSync(file));
+                var coverage = JSON.parse(fs.readFileSync(file), 'utf8'),
+                    filtered;
+                filtered = Object.keys(coverage).filter(function (k) { return k.match(/foo/) || k.match(/bar/); });
+                test.ok(filtered.length === 2);
+              });
+              test.done();
+            });
+        });
+    }
+};


### PR DESCRIPTION
This is an attempt to address the usage of Istanbul in a multi-process environment.  Rather than addressing the specifics of a particular multi-process technique, a tool is added that could be of use to different methods: a `--include-pid` option is added to append the process id to coverage filenames.  This has worked out well for use with the node cluster module.  Generating your own directory names for use with `--dir` won't work with the cluster module since you can't adjust parameters per child.

This patch may help address a number of current and old issues: #97, #115, #147, #199, and maybe others.

Test case code is not yet written but thought I'd put this patch out for feedback now.

From the commit:
- Add an option to append the process id to the coverage filename.
- Including a PID in filenames can be used to make it easier to perform
  coverage testing of multiple process applications. If invoked
  properly, each process will create a unique coverage file which can
  then be merged during reporting.
- Add example in the README of how to use this support with the cluster
  module.