### PR TITLE
Fixing branchMap locations, kind of, and adding tests for said fix

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -841,10 +841,9 @@
                 hint = this.currentState.currentHint,
                 ignoreThen = !alreadyIgnoring && hint && hint.type === 'if',
                 ignoreElse = !alreadyIgnoring && hint && hint.type === 'else',
-                line = node.loc.start.line,
-                col = node.loc.start.column,
-                start = { line: line, column: col },
-                end = { line: line, column: col },
+                loc = node.loc,
+                start = { line: loc.start.line, column: loc.start.column },
+                end = { line: loc.end.line, column: loc.end.column },
                 bName = this.branchName('if', walker.startLineForNode(node), [
                     { start: start, end: end, skip: ignoreThen || undefined },
                     { start: start, end: end, skip: ignoreElse || undefined }

--- a/test/instrumentation/test-if.js
+++ b/test/instrumentation/test-if.js
@@ -18,10 +18,16 @@ module.exports = {
             },
             "should cover then path": function (test) {
                 verifier.verify(test, [ 20, 10 ], 20, { lines: { 1: 1, 2: 1, 3: 1 }, branches: { '1': [ 1, 0 ] }, functions: {}, statements: { '1': 1, '2': 1, '3': 1 } });
+                var cov = verifier.getFileCoverage(),
+                    thenBranch = cov.branchMap[1].locations[0];
+                test.deepEqual({ start: { line: 2, column: 0 }, end: { line: 3, column: 20 } }, thenBranch);
                 test.done();
             },
             "should cover else path": function (test) {
                 verifier.verify(test, [ 10, 20 ], -1, { lines: { 1: 1, 2: 1, 3: 0 }, branches: { '1': [ 0, 1 ] }, functions: {}, statements: { '1': 1, '2': 1, '3': 0 } });
+                var cov = verifier.getFileCoverage(),
+                    elseBranch = cov.branchMap[1].locations[1];
+                test.deepEqual({ start: { line: 2, column: 0 }, end: { line: 3, column: 20 } }, elseBranch);
                 test.done();
             }
         },

--- a/test/instrumentation/test-switch.js
+++ b/test/instrumentation/test-switch.js
@@ -61,14 +61,23 @@ module.exports = {
             },
             "should cover one path": function (test) {
                 verifier.verify(test, [ "1" ], "one", { lines: { 1: 1, 2: 1, 3: 1, 4: 0, 5: 0 }, branches: { '1': [ 1, 0, 0 ] }, functions: {}, statements: { '1': 1, '2': 1, '3': 1, '4': 1, '5': 0, '6': 0, '7': 0 } });
+                var cov = verifier.getFileCoverage(),
+                    pathOne = cov.branchMap[1].locations[0];
+                test.deepEqual({ start: { line: 3, column: 3 }, end: { line: 3, column: 35 } }, pathOne);
                 test.done();
             },
             "should cover two path": function (test) {
                 verifier.verify(test, [ "2" ], "two", { lines: { 1: 1, 2: 1, 3: 0, 4: 1, 5: 0 }, branches: { '1': [ 0, 1, 0 ] }, functions: {}, statements: { '1': 1, '2': 1, '3': 0, '4': 0, '5': 1, '6': 1, '7': 0 } });
+                var cov = verifier.getFileCoverage(),
+                    pathTwo = cov.branchMap[1].locations[1];
+                test.deepEqual({ start: { line: 4, column: 3 }, end: { line: 4, column: 35 } }, pathTwo);
                 test.done();
             },
             "should cover unknown path": function (test) {
                 verifier.verify(test, [ "4" ], "three", { lines: { 1: 1, 2: 1, 3: 0, 4: 0, 5: 1 }, branches: { '1': [ 0, 0, 1 ] }, functions: {}, statements: { '1': 1, '2': 1, '3': 0, '4': 0, '5': 0, '6': 0, '7': 1 } });
+                var cov = verifier.getFileCoverage(),
+                    pathDefault = cov.branchMap[1].locations[2];
+                test.deepEqual({ start: { line: 5, column: 3 }, end: { line: 5, column: 29 } }, pathDefault);
                 test.done();
             }
         },


### PR DESCRIPTION
I saw that `start` and `end` locations of each `branchMap` value were always the same location (actually the `start` one). Here's a fix.

Ultimately, I think that these locations should be the location of the `consequent` or `alternate`, but when I tried to implement this, those locations weren't being made available in, for example, `node.consequent`. It looked like a perfectly valid `BlockStatement` (for example), but without a `loc:` attribute.