### PR TITLE
"Instrument code" API example correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ All the features of istanbul can be accessed as a library.
 #### Instrument code
 
 ```javascript
-    var instrumenter = new require('istanbul').Instrumenter();
+    var istanbul = require('istanbul');
+    var instrumenter = new istanbul.Instrumenter();
 
     var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { return 42; }',
         'filename.js');


### PR DESCRIPTION
Executing the ["Instrument code" API example](https://github.com/gotwarlost/istanbul#instrument-code) code yields the following error:

```sh
/Users/rob/code/istanbul/instrument-code.js:3
var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { re
                                 ^
TypeError: Cannot call method 'instrumentSync' of undefined
    at Object.<anonymous> (/Users/rob/code/istanbul/instrument-code.js:3:34)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

This PR corrects the error by separating the `istanbul` import, and the `Instrumenter` instantiation.