### PR TITLE
Fix html reporter empty sourceStore problem with browserify

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -306,6 +306,15 @@ function getReportClass(stats, watermark) {
     }
 }
 
+function isEmptySourceStore(sourceStore) {
+    if (!sourceStore) {
+        return true;
+    }
+
+    var cache = sourceStore.sourceCache;
+    return cache && !Object.keys(cache).length;
+}
+
 /**
  * a `Report` implementation that produces HTML coverage reports.
  *
@@ -326,7 +335,8 @@ function HtmlReport(opts) {
     Report.call(this);
     this.opts = opts || {};
     this.opts.dir = this.opts.dir || path.resolve(process.cwd(), 'html-report');
-    this.opts.sourceStore = this.opts.sourceStore || Store.create('fslookup');
+    this.opts.sourceStore = isEmptySourceStore(this.opts.sourceStore) ?
+        Store.create('fslookup') : this.opts.sourceStore;
     this.opts.linkMapper = this.opts.linkMapper || this.standardLinkMapper();
     this.opts.writer = this.opts.writer || null;
     this.opts.templateData = { datetime: Date() };


### PR DESCRIPTION
i use this istanbul module for coverage reports.

karma-browserify + browserify-istanbul is powerful but has some issue.

the issue is sourceStore to be empty like below code.

```javascript
console.log(sourceStore);    // { sourceCache: {} }
// this are make writeDetailPage() -> sourceText to undefined.
```

so i add some validate function for check empty sourceStore object.


