### PR TITLE
use supports-color module

### DIFF
--- a/lib/report/common/defaults.js
+++ b/lib/report/common/defaults.js
@@ -4,6 +4,7 @@
  */
 
 var Report  = require('../index');
+var supportsColor = require('supports-color');
 
 module.exports = {
     watermarks: function () {
@@ -23,7 +24,7 @@ module.exports = {
 
     colorize: function (str, clazz) {
         /* istanbul ignore if: untestable in batch mode */
-        if (process.stdout.isTTY) {
+        if (supportsColor) {
             switch (clazz) {
                 case 'low' : str = '\033[91m' + str + '\033[0m'; break;
                 case 'medium': str = '\033[93m' + str + '\033[0m'; break;

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "fileset": "0.1.x",
         "which": "1.0.x",
         "async": "0.9.x",
+        "supports-color": "1.2.x",
         "abbrev": "1.0.x",
         "wordwrap": "0.0.x",
         "resolve": "0.7.x",


### PR DESCRIPTION
To check if colors should be used or not.

It allows you to force colors through the use of command line flags.

See https://github.com/sindresorhus/supports-color/blob/2ae39320b7ca26c2803b4da531ed9bbcc40d78a3/index.js#L11

The reason I need this is that when running a CI job on jenkins colored output is supported even though it's not run in a tty.

To test the output when running in no-tty mode, you can pipe the istanbul command to cat.
```
$ istanbul cover _mocha | cat
```

After applying my patch, you will still not get colors when running the above. But you can run the following to force it:
```
$ istanbul cover --colors _mocha | cat
```

Added bonus is that the module does thorough testing on more parameters and should do the right thing anywhere.

I'm not sure how to document these CLI flags in the existing code.