### PR TITLE
Update to Esprima 2.0 (refs #141).

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "url": "git://github.com/gotwarlost/istanbul.git"
     },
     "dependencies": {
-        "esprima": "1.2.x",
+        "esprima": "2.0.x",
         "escodegen": "1.3.x",
         "handlebars": "1.3.x",
         "mkdirp": "0.5.x",


### PR DESCRIPTION
See http://blog.jquery.com/2015/02/06/esprima-2-0-released/. This sets the step for Istanbul to start instrumenting and tracking the coverage of ES6 syntax.

No feature or performance regression was observed.