### PR TITLE
Add total coverage summary to json-summary report

### DIFF
--- a/lib/report/json-summary.js
+++ b/lib/report/json-summary.js
@@ -47,16 +47,21 @@ Report.mix(JsonSummaryReport, {
             writer = this.opts.writer || new Writer(sync),
             that = this;
 
+        var summaries = [],
+            finalSummary;
+        collector.files().forEach(function (file) {
+            summaries.push(objectUtils.summarizeFileCoverage(collector.fileCoverageFor(file)));
+        });
+        finalSummary = objectUtils.mergeSummaryObjects.apply(null, summaries);
+
         writer.on('done', function () { that.emit('done'); });
         writer.writeFile(outputFile, function (contentWriter) {
-            var first = true;
             contentWriter.println("{");
+            contentWriter.write('"total":');
+            contentWriter.write(JSON.stringify(finalSummary));
+
             collector.files().forEach(function (key) {
-                if (first) {
-                    first = false;
-                } else {
-                    contentWriter.println(",");
-                }
+                contentWriter.println(",");
                 contentWriter.write(JSON.stringify(key));
                 contentWriter.write(":");
                 contentWriter.write(JSON.stringify(objectUtils.summarizeFileCoverage(collector.fileCoverageFor(key))));

--- a/test/cli/test-json-summary-report.js
+++ b/test/cli/test-json-summary-report.js
@@ -10,7 +10,8 @@ var path = require('path'),
     runCover = helper.runCommand.bind(null, COVER_COMMAND),
     Reporter = require('../../lib/report/json-summary'),
     Collector = require('../../lib/collector'),
-    existsSync = fs.existsSync || path.existsSync;
+    existsSync = fs.existsSync || path.existsSync,
+    objectUtils = require('../../lib/object-utils');
 
 module.exports = {
     setUp: function (cb) {
@@ -36,6 +37,15 @@ module.exports = {
         obj = JSON.parse(fs.readFileSync(file, 'utf8'));
         collector.add(obj);
         reporter.writeReport(collector, true);
+
+        var summaries = [],
+            finalSummary;
+        collector.files().forEach(function (file) {
+            summaries.push(objectUtils.summarizeFileCoverage(collector.fileCoverageFor(file)));
+        });
+        finalSummary = objectUtils.mergeSummaryObjects.apply(null, summaries);
+        obj.total = finalSummary;
+        
         test.ok(existsSync(jsonFile));
         reportObj = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
         test.deepEqual(Object.keys(obj).sort(), Object.keys(reportObj).sort());


### PR DESCRIPTION
Adds the final coverage summary to the top of the json-summary report. This gives similar functionality to the text-summary report which is expected and useful in the form as json as well.