### PR TITLE
Converted relativeName sep to / and then do the work only with /

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -306,6 +306,10 @@ function getReportClass(stats, watermark) {
     }
 }
 
+function cleanPath(name){
+    return (SEP !== '/') ? name.split(SEP).join('/') : name;
+}
+
 /**
  * a `Report` implementation that produces HTML coverage reports.
  *
@@ -355,11 +359,11 @@ Report.mix(HtmlReport, {
 
         for (i = 0; i < nodePath.length; i += 1) {
             linkPath.push('<a href="' + linkMapper.ancestor(node, i + 1) + '">' +
-                (nodePath[i].relativeName || 'All files') + '</a>');
+                (cleanPath(nodePath[i].relativeName) || 'All files') + '</a>');
         }
         linkPath.reverse();
         return linkPath.length > 0 ? linkPath.join(' &#187; ') + ' &#187; ' +
-            node.displayShortName() : '';
+            cleanPath(node.displayShortName()) : '';
     },
 
     fillTemplate: function (node, templateData) {
@@ -441,7 +445,7 @@ Report.mix(HtmlReport, {
                 data = {
                     metrics: metrics,
                     reportClasses: reportClasses,
-                    file: child.displayShortName(),
+                    file: cleanPath(child.displayShortName()),
                     output: linkMapper.fromParent(child)
                 };
             writer.write(summaryLineTemplate(data) + '\n');
@@ -474,30 +478,22 @@ Report.mix(HtmlReport, {
     standardLinkMapper: function () {
         return {
             fromParent: function (node) {
-                var i = 0,
-                    relativeName = node.relativeName,
-                    ch;
-                if (SEP !== '/') {
-                    relativeName = '';
-                    for (i = 0; i < node.relativeName.length; i += 1) {
-                        ch = node.relativeName.charAt(i);
-                        if (ch === SEP) {
-                            relativeName += '/';
-                        } else {
-                            relativeName += ch;
-                        }
-                    }
-                }
+                var relativeName = cleanPath(node.relativeName);
+                
                 return node.kind === 'dir' ? relativeName + 'index.html' : relativeName + '.html';
             },
             ancestorHref: function (node, num) {
                 var href = '',
+                    notDot = function(part) {
+                        return part !== '.';
+                    },
                     separated,
                     levels,
                     i,
                     j;
+
                 for (i = 0; i < num; i += 1) {
-                    separated = node.relativeName.split(SEP);
+                    separated = cleanPath(node.relativeName).split('/').filter(notDot);
                     levels = separated.length - 1;
                     for (j = 0; j < levels; j += 1) {
                         href += '../';


### PR DESCRIPTION
This PR fixes #315 and #79. Basically, it converts relativeName seps to '/' when they are different to it (following the same strategy of fromParent method), so all the processing is done using '/' as separator. Also added a check to remove single dots in relativeName.