### PR TITLE
handle relative paths in check-coverage

### DIFF
--- a/lib/command/check-coverage.js
+++ b/lib/command/check-coverage.js
@@ -14,6 +14,12 @@ var nopt = require('nopt'),
     Command = require('./index'),
     configuration = require('../config');
 
+if (!path.isAbsolute) {
+    path.isAbsolute = function(file) {
+        return path.resolve(file) === path.normalize(file);
+    };
+}
+
 function CheckCoverageCommand() {
     Command.call(this);
 }
@@ -24,11 +30,15 @@ function removeFiles(covObj, root, files) {
 
     // Create lookup table.
     files.forEach(function (file) {
-        filesObj[path.join(root, file)] = true;
+        filesObj[file] = true;
     });
 
     Object.keys(covObj).forEach(function (key) {
-        if (filesObj[key] !== true) {
+        // Exclude keys will always be relative, but covObj keys can be absolute or relative
+        var excludeKey = path.isAbsolute(key) ? path.relative(root, key) : key;
+        // Also normalize for files that start with `./`, etc.
+        excludeKey = path.normalize(excludeKey);
+        if (filesObj[excludeKey] !== true) {
             obj[key] = covObj[key];
         }
     });


### PR DESCRIPTION
#323 
Sorry there is no test for this particular case, but it's kinda hard to do, because `cover` command produces absolute paths in `coverage.json`.