### PR TITLE
Fail check-coverage command if no coverage found

### DIFF
--- a/lib/command/check-coverage.js
+++ b/lib/command/check-coverage.js
@@ -105,6 +105,9 @@ Command.mix(CheckCoverageCommand, {
             includes: [ includePattern ]
         }, function (err, files) {
             if (err) { throw err; }
+            if (files.length === 0) {
+               return callback('ERROR: No coverage files found.');
+            }
             files.forEach(function (file) {
                 var coverageObject = JSON.parse(fs.readFileSync(file, 'utf8'));
                 collector.add(coverageObject);

--- a/test/cli/test-check-coverage-command.js
+++ b/test/cli/test-check-coverage-command.js
@@ -57,7 +57,7 @@ module.exports = {
                 test.ok(results.grepError(/Coverage for lines .* global/));
                 test.done();
             });
-        },
+        },        
         "should fail with multiple reasons when multiple thresholds violated": function (test) {
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
             run([ '--statements=72', '--functions=50', '--branches=72', '--lines=72' ], function (results) {
@@ -112,10 +112,11 @@ module.exports = {
                 test.done();
             });
         },
-        "should succeed with any threshold when no coverage found": function (test) {
-            test.ok(existsSync(path.resolve(OUTPUT_DIR, 'coverage.json')));
-            run([ '--statements', '72', '**/foobar.json' ], function (results) {
-                test.ok(results.succeeded());
+        "should fail when no coverage found": function (test) {
+            test.ok(!existsSync(path.resolve(OUTPUT_DIR, 'no-matching-coverage.json')));
+            run([ 'no-matching-coverage.json' ], function (results) {
+                test.ok(!results.succeeded());
+                test.ok(results.grepError(/No coverage files found./));
                 test.done();
             });
         }


### PR DESCRIPTION
If no coverage files were checked, then the command should return an error. This functionality better aligns with other JS tools (karma and mocha come to mind) that will treat
not running any tests as an error.