### PR TITLE
check for the existence of the obj before using it

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -171,7 +171,9 @@ function annotateLines(fileCoverage, structuredText) {
     if (!lineStats) { return; }
     Object.keys(lineStats).forEach(function (lineNumber) {
         var count = lineStats[lineNumber];
-        structuredText[lineNumber].covered = count > 0 ? 'yes' : 'no';
+        if (structuredText[lineNumber]) {
+          structuredText[lineNumber].covered = count > 0 ? 'yes' : 'no';
+        }
     });
     structuredText.forEach(function (item) {
         if (item.covered === null) {


### PR DESCRIPTION
i know this is not the best solution and is missing tests. Wasn't really sure how to test this. I ran across this because I had an empty CoffeeScript file that karma-coverage was dying on and this 'fixed' the problem. The problem being an error was thrown saying could not set the property covered of undefined.