### PR TITLE
Avoid modifying global objects

### DIFF
--- a/lib/command/check-coverage.js
+++ b/lib/command/check-coverage.js
@@ -14,10 +14,12 @@ var nopt = require('nopt'),
     Command = require('./index'),
     configuration = require('../config');
 
-if (!path.isAbsolute) {
-    path.isAbsolute = function(file) {
-        return path.resolve(file) === path.normalize(file);
-    };
+function isAbsolute(file) {
+    if (path.isAbsolute) {
+        return path.isAbsolute(file);
+    }
+
+    return path.resolve(file) === path.normalize(file);
 }
 
 function CheckCoverageCommand() {
@@ -35,7 +37,7 @@ function removeFiles(covObj, root, files) {
 
     Object.keys(covObj).forEach(function (key) {
         // Exclude keys will always be relative, but covObj keys can be absolute or relative
-        var excludeKey = path.isAbsolute(key) ? path.relative(root, key) : key;
+        var excludeKey = isAbsolute(key) ? path.relative(root, key) : key;
         // Also normalize for files that start with `./`, etc.
         excludeKey = path.normalize(excludeKey);
         if (filesObj[excludeKey] !== true) {


### PR DESCRIPTION
At least partially fixes #334 - I kept the implementation as is, but removed the side effect of modifying a global object.