### PR TITLE
Allow file extensions in hookRequire options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var path = require('path'),
     Report = require('./lib/report'),
     meta = require('./lib/util/meta');
 
-//register our standard plaugins
+//register our standard plugins
 require('./lib/register-plugins');
 
 /**

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -35,7 +35,7 @@ var path = require('path'),
     fs = require('fs'),
     Module = require('module'),
     vm = require('vm'),
-    originalLoader = Module._extensions['.js'],
+    originalLoaders = {},
     originalCreateScript = vm.createScript,
     originalRunInThisContext = vm.runInThisContext;
 
@@ -90,21 +90,27 @@ function unloadRequireCache(matcher) {
  */
 function hookRequire(matcher, transformer, options) {
     options = options || {};
-    var fn = transformFn(matcher, transformer, options.verbose),
+    var extensions,
+        fn = transformFn(matcher, transformer, options.verbose),
         postLoadHook = options.postLoadHook &&
             typeof options.postLoadHook === 'function' ? options.postLoadHook : null;
 
-    Module._extensions['.js'] = function (module, filename) {
-        var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
-        if (ret.changed) {
-            module._compile(ret.code, filename);
-        } else {
-            originalLoader(module, filename);
-        }
-        if (postLoadHook) {
-            postLoadHook(filename);
-        }
-    };
+    extensions = options.extensions || ['.js'];
+
+    extensions.forEach(function(ext){
+        originalLoaders[ext] = Module._extensions[ext];
+        Module._extensions[ext] = function (module, filename) {
+            var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
+            if (ret.changed) {
+                module._compile(ret.code, filename);
+            } else {
+                originalLoaders[ext](module, filename);
+            }
+            if (postLoadHook) {
+                postLoadHook(filename);
+            }
+        };
+    });
 }
 /**
  * unhook `require` to restore it to its original state.
@@ -112,7 +118,9 @@ function hookRequire(matcher, transformer, options) {
  * @static
  */
 function unhookRequire() {
-    Module._extensions['.js'] = originalLoader;
+    Object.keys(originalLoaders).forEach(function(ext) {
+        Module._extensions[ext] = originalLoaders[ext];
+    });
 }
 /**
  * hooks `vm.createScript` to return transformed code out of which a `Script` object will be created.

--- a/test/other/data/bar.es6
+++ b/test/other/data/bar.es6
@@ -1,0 +1,4 @@
+module.exports = {
+    bar: function () { return 'bar'; }
+};
+


### PR DESCRIPTION
Currently people mixing in `.es6` files are unable to run istanbul on them. This PR allows file extensions to be passed with the `hookRequire` options.