### PR TITLE
Left align file columns

### DIFF
--- a/lib/assets/base.css
+++ b/lib/assets/base.css
@@ -131,7 +131,7 @@ div.coverage-summary th.pct { border-right: none !important; }
 div.coverage-summary th.abs { border-left: none !important; text-align: right; }
 div.coverage-summary td.pct { text-align: right; border-left: 1px solid #666; }
 div.coverage-summary td.abs { text-align: right; font-size: 90%; color: #444; border-right: 1px solid #666; }
-div.coverage-summary td.file { text-align: right; border-left: 1px solid #666; white-space: nowrap;  }
+div.coverage-summary td.file { border-left: 1px solid #666; white-space: nowrap;  }
 div.coverage-summary td.pic { min-width: 120px !important;  }
 div.coverage-summary a:link { text-decoration: none; color: #000; }
 div.coverage-summary a:visited { text-decoration: none; color: #333; }


### PR DESCRIPTION
Its very difficult to visually parse sorted files when right aligned. Left align the file column instead.

Before:
![istanbul-before](https://cloud.githubusercontent.com/assets/285916/7079025/65e0eeae-deed-11e4-9f0e-c53b90f25686.png)

After:
![istanbul-after](https://cloud.githubusercontent.com/assets/285916/7079026/675629ac-deed-11e4-8f24-5191136dedfe.png)