### PR TITLE
Do not override originalLoaders if it is already set

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -98,7 +98,9 @@ function hookRequire(matcher, transformer, options) {
     extensions = options.extensions || ['.js'];
 
     extensions.forEach(function(ext){
-        originalLoaders[ext] = Module._extensions[ext];
+        if (!(ext in originalLoaders)) { 
+            originalLoaders[ext] = Module._extensions[ext];
+        } 
         Module._extensions[ext] = function (module, filename) {
             var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
             if (ret.changed) {

--- a/test/other/test-hook.js
+++ b/test/other/test-hook.js
@@ -35,6 +35,15 @@ module.exports = {
             test.done();
         },
 
+        "twice it should save original code": function (test) {
+            hook.hookRequire(matcher, transformer, { verbose: true });
+            hook.unhookRequire();
+            var foo = require('./data/foo');
+            test.ok(foo.foo);
+            test.equals('foo', foo.foo());
+            test.done();
+        },
+
         "postLoadHook should be called": function (test) {
             var called = null,
                 opts = { postLoadHook: function (file) { called = file; }},


### PR DESCRIPTION
Overriding `originalLoaders[ext]` if it is already set may lead to unexpected behaviour.