### PR TITLE
Wrong object modified for sourcemap offset when adding preamble

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -549,8 +549,8 @@
             if (generated.map && generated.code) {
                 lineCount = preamble.split(/\r\n|\r|\n/).length;
                 // offset all the generated line numbers by the number of lines in the preamble
-                for (i = 0; i < generated.map._mappings.length; i += 1) {
-                    generated.map._mappings[i].generatedLine += lineCount;
+                for (i = 0; i < generated.map._mappings._array.length; i += 1) {
+                    generated.map._mappings._array[i].generatedLine += lineCount;
                 }
                 this.sourceMap = generated.map;
                 generated = generated.code;


### PR DESCRIPTION
The object containing the line and column numbers in the source map is in map._mappings._array[i], not map._mappings[i].

This causes the preamble offset to be applied correctly.

See https://github.com/mozilla/source-map/blob/388b8f8d7a34e8fa0cc84764aaac2d4e93c73985/lib/source-map/mapping-list.js#L48