### PR TITLE
Improve cmd line docs: need to run `help command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Available commands are:
 Command names can be abbreviated as long as the abbreviation is unambiguous
 ```
 
+To get detail help for a command and what command-line options it supports, run:
+
+    istanbul help <command>
+
+(Most of the command line options are not covered in this document.)
+
 #### The `cover` command
 
     $ istanbul cover my-test-script.js -- my test args

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Available commands are:
 Command names can be abbreviated as long as the abbreviation is unambiguous
 ```
 
-To get detail help for a command and what command-line options it supports, run:
+To get detailed help for a command and what command-line options it supports, run:
 
     istanbul help <command>
 


### PR DESCRIPTION
Make it very clear that command line options are mostly not described here.

TODO: Find out how can the user discover that there are command line options that are not command-specific such as `--include-all-sources`