### PR TITLE
Expose extensions option

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -146,7 +146,9 @@ function run(args, commandName, enableHooks, callback) {
         excludes.push(path.relative(process.cwd(), path.join(reportingDir, '**', '*')));
         matcherFor({
             root: config.instrumentation.root() || process.cwd(),
-            includes: opts.i || [ '**/*.js' ],
+            includes: opts.i || config.instrumentation.extensions().map(function (ext) {
+                return '**/*' + ext;
+            }),
             excludes: excludes
         },
             function (err, matchFn) {
@@ -155,7 +157,7 @@ function run(args, commandName, enableHooks, callback) {
                 var coverageVar = '$$cov_' + new Date().getTime() + '$$',
                     instrumenter = new Instrumenter({ coverageVariable: coverageVar , preserveComments: preserveComments}),
                     transformer = instrumenter.instrumentSync.bind(instrumenter),
-                    hookOpts = { verbose: verbose },
+                    hookOpts = { verbose: verbose, extensions: config.instrumentation.extensions() },
                     postRequireHook = config.hooks.postRequireHook(),
                     postLoadHookFile;
 

--- a/lib/command/instrument.js
+++ b/lib/command/instrument.js
@@ -52,12 +52,12 @@ BaselineCollector.prototype = {
 };
 
 
-function processFiles(instrumenter, inputDir, outputDir, relativeNames) {
+function processFiles(instrumenter, inputDir, outputDir, relativeNames, extensions) {
     var processor = function (name, callback) {
             var inputFile = path.resolve(inputDir, name),
                 outputFile = path.resolve(outputDir, name),
                 inputFileExtenstion = path.extname(inputFile),
-                isJavaScriptFile = (inputFileExtenstion === '.js'),
+                isJavaScriptFile = extensions.indexOf(inputFileExtenstion) > -1,
                 oDir = path.dirname(outputFile),
                 readStream, writeStream;
 
@@ -207,7 +207,9 @@ Command.mix(InstrumentCommand, {
             includes = ['**/*'];
         }
         else {
-            includes = ['**/*.js'];
+            includes = iOpts.extensions().map(function(ext) {
+                return '**/*' + ext;
+            });
         }
 
         instrumenter = new Instrumenter({
@@ -239,7 +241,7 @@ Command.mix(InstrumentCommand, {
                 relative: true
             }, function (err, files) {
                 if (err) { return callback(err); }
-                processFiles(instrumenter, file, output, files);
+                processFiles(instrumenter, file, output, files, iOpts.extensions());
             });
         } else {
             if (output) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,7 @@ function defaultConfig(includeBackCompatAttrs) {
         verbose: false,
         instrumentation: {
             root: '.',
+            extensions: ['.js'],
             'default-excludes': true,
             excludes: [],
             'embed-source': false,
@@ -183,7 +184,7 @@ function InstrumentOptions(config) {
 
 
 addMethods(InstrumentOptions,
-    'defaultExcludes', 'completeCopy',
+    'extensions', 'defaultExcludes', 'completeCopy',
     'embedSource', 'variable', 'compact', 'preserveComments',
     'saveBaseline', 'baselineFile',
     'includeAllSources', 'includePid');


### PR DESCRIPTION
Would you mind exposing the `extensions` option for hooks introduced by #336 to the configuration file? That way it is possible to use istanbul in an environment where JavaScript files have different extensions (like [streamline.js](/Sage/streamlinejs)).