### PR TITLE
next report text-lcov, reports lcov to stdout

### DIFF
--- a/lib/report/text-lcov.js
+++ b/lib/report/text-lcov.js
@@ -1,0 +1,50 @@
+var LcovOnly = require('./lcovonly'),
+  util = require('util');
+
+/**
+ * a `Report` implementation that produces an LCOV coverage and prints it
+ *  to standard out.
+ *
+ * Usage
+ * -----
+ *
+ *      var report = require('istanbul').Report.create('text-lcov');
+ *
+ * @class TextLcov
+ * @module report
+ * @extends LcovOnly
+ * @constructor
+ * @param {Object} opts optional
+ * @param {String} [opts.log] the method used to log to console.
+ */
+function TextLcov(opts) {
+    var that = this;
+
+    LcovOnly.call(this);
+
+    this.opts = opts || {};
+    this.opts.log = this.opts.log || console.log;
+    this.opts.writer = {
+        println: function (ln) {
+            that.opts.log(ln);
+        }
+    };
+}
+
+TextLcov.TYPE = 'text-lcov';
+util.inherits(TextLcov, LcovOnly);
+
+LcovOnly.super_.mix(TextLcov, {
+    writeReport: function (collector) {
+        var that = this,
+            writer = this.opts.writer;
+
+        collector.files().forEach(function (key) {
+            that.writeFileCoverage(writer, collector.fileCoverageFor(key));
+        });
+
+        this.emit('done');
+    }
+});
+
+module.exports = TextLcov;

--- a/test/cli/test-text-lcov-report.js
+++ b/test/cli/test-text-lcov-report.js
@@ -1,0 +1,42 @@
+/*jslint nomen: true */
+var path = require('path'),
+    fs = require('fs'),
+    mkdirp = require('mkdirp'),
+    rimraf = require('rimraf'),
+    helper = require('../cli-helper'),
+    DIR = path.resolve(__dirname, 'sample-project'),
+    OUTPUT_DIR = path.resolve(DIR, 'coverage'),
+    COVER_COMMAND = 'cover',
+    runCover = helper.runCommand.bind(null, COVER_COMMAND),
+    Reporter = require('../../lib/report/text-lcov'),
+    Collector = require('../../lib/collector');
+
+module.exports = {
+    setUp: function (cb) {
+        rimraf.sync(OUTPUT_DIR);
+        mkdirp.sync(OUTPUT_DIR);
+        helper.resetOpts();
+        runCover([ 'test/run.js', '--report', 'none' ], function (/* results */) {
+            cb();
+        });
+    },
+    tearDown: function (cb) {
+        rimraf.sync(OUTPUT_DIR);
+        cb();
+    },
+    "should print lcov.info to standard out": function (test) {
+        var file = path.resolve(OUTPUT_DIR, 'coverage.json'),
+            reporter = new Reporter({
+                log: function (ln) {
+                    output += ln;
+                }
+            }),
+            collector = new Collector(),
+            output = '';
+
+        collector.add(JSON.parse(fs.readFileSync(file, 'utf8')));
+        reporter.writeReport(collector, true);
+        test.ok(output.match('TN:SF:'), 'failed to output report');
+        test.done();
+    }
+};


### PR DESCRIPTION
I've added a new report which inherits from `lcovonly`, but reports lcov to the console, rather than to a file.

This is really useful for sites like https://coveralls.io, which expect that an lcov report will be piped to them.