### PR TITLE
When setting up the `reportDir` add it to `reporter.dir`

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -127,6 +127,7 @@ function run(args, commandName, enableHooks, callback) {
     if (enableHooks) {
         reportingDir = path.resolve(config.reporting.dir());
         mkdirp.sync(reportingDir); //ensure we fail early if we cannot do this
+        reporter.dir = reportingDir;
         reporter.addAll(config.reporting.reports());
         if (config.reporting.print() !== 'none') {
             switch (config.reporting.print()) {


### PR DESCRIPTION
This will ensure that all reports are written to the proper directory even if the test file change the directory during the execution of the tests.

Fixes #318