### PR TITLE
Lint Cleanup

### DIFF
--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -11,7 +11,7 @@ var path = require('path'),
     Report = require('./index'),
     TreeSummarizer = require('../util/tree-summarizer'),
     utils = require('../object-utils'),
-    PCT_COLS = 10,
+    PCT_COLS = 20,
     TAB_SIZE = 3,
     DELIM = ' |',
     COL_DELIM = '-|';
@@ -107,11 +107,16 @@ function tableHeader(maxNameCols) {
 
 function tableRow(node, maxNameCols, level, watermarks) {
     var name = nodeName(node),
-        statements = node.metrics.statements.pct,
-        branches = node.metrics.branches.pct,
-        functions = node.metrics.functions.pct,
-        lines = node.metrics.lines.pct,
+        statements = node.metrics.statements.pct + ' (' + node.metrics.statements.covered + '/' + node.metrics.statements.total + ')',
+        branches = node.metrics.branches.pct + ' (' + node.metrics.branches.covered + '/' + node.metrics.branches.total + ')',
+        functions = node.metrics.functions.pct + ' (' + node.metrics.functions.covered + '/' + node.metrics.functions.total + ')',
+        lines = node.metrics.lines.pct + ' (' + node.metrics.lines.covered + '/' + node.metrics.lines.total + ')',
         elements = [];
+
+    node.metrics.statements.total === 0 && (statements = 'N/A');
+    node.metrics.branches.total === 0 && (branches = 'N/A');
+    node.metrics.functions.total === 0 && (functions = 'N/A');
+    node.metrics.lines.total === 0 && (lines = 'N/A');
 
     elements.push(formatName(name, maxNameCols, level, defaults.classFor('statements', node.metrics, watermarks)));
     elements.push(formatPct(statements, defaults.classFor('statements', node.metrics, watermarks)));

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -113,10 +113,18 @@ function tableRow(node, maxNameCols, level, watermarks) {
         lines = node.metrics.lines.pct + ' (' + node.metrics.lines.covered + '/' + node.metrics.lines.total + ')',
         elements = [];
 
-    node.metrics.statements.total === 0 && (statements = 'N/A');
-    node.metrics.branches.total === 0 && (branches = 'N/A');
-    node.metrics.functions.total === 0 && (functions = 'N/A');
-    node.metrics.lines.total === 0 && (lines = 'N/A');
+    if (node.metrics.statements.total === 0) {
+        statements = 'N/A';
+    }
+    if (node.metrics.branches.total === 0) {
+        branches = 'N/A';
+    }
+    if (node.metrics.functions.total === 0) {
+        functions = 'N/A';
+    }
+    if (node.metrics.lines.total === 0) {
+        lines = 'N/A';
+    }
 
     elements.push(formatName(name, maxNameCols, level, defaults.classFor('statements', node.metrics, watermarks)));
     elements.push(formatPct(statements, defaults.classFor('statements', node.metrics, watermarks)));


### PR DESCRIPTION
This cleans up the lint errors from #356 which makes the text report look like this:

```
--------------------|---------------------|---------------------|---------------------|---------------------|
File                |             % Stmts |          % Branches |             % Funcs |             % Lines |
--------------------|---------------------|---------------------|---------------------|---------------------|
   git-raw-commits/ |         100 (93/93) |         100 (10/10) |         100 (26/26) |         100 (93/93) |
      index.js      |         100 (33/33) |           100 (8/8) |           100 (8/8) |         100 (33/33) |
      test.js       |         100 (60/60) |           100 (2/2) |         100 (18/18) |         100 (60/60) |
--------------------|---------------------|---------------------|---------------------|---------------------|
All files           |         100 (93/93) |         100 (10/10) |         100 (26/26) |         100 (93/93) |
--------------------|---------------------|---------------------|---------------------|---------------------|
```

@gotwarlost Good?