### PR TITLE
Fixes #238 (added a poorman's clone)

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -352,12 +352,13 @@
      *
      * @method incrementIgnoredTotals
      * @static
-     * @param {Object} fileCoverage File coverage object
+     * @param {Object} cov File coverage object
      * @return {Object} New file coverage object
      */
-    function incrementIgnoredTotals(fileCoverage) {
-        // TODO: implementation of extend() function needed
-        // fileCoverage = extend(fileCoverage);
+    function incrementIgnoredTotals(cov) {
+        //TODO: This may be slow in the browser and may break in older browsers
+        //      Look into using a library that works in Node and the browser
+        var fileCoverage = JSON.parse(JSON.stringify(cov));
 
         [
             {mapKey: 'statementMap', hitsKey: 's'},

--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -346,6 +346,50 @@
         return ret;
     }
 
+    /**
+     * Creates new file coverage object with incremented hits count
+     * on skipped statements, branches and functions
+     *
+     * @method incrementIgnoredTotals
+     * @static
+     * @param {Object} fileCoverage File coverage object
+     * @return {Object} New file coverage object
+     */
+    function incrementIgnoredTotals(fileCoverage) {
+        // TODO: implementation of extend() function needed
+        // fileCoverage = extend(fileCoverage);
+
+        [
+            {mapKey: 'statementMap', hitsKey: 's'},
+            {mapKey: 'branchMap', hitsKey: 'b'},
+            {mapKey: 'fnMap', hitsKey: 'f'}
+        ].forEach(function (keys) {
+            Object.keys(fileCoverage[keys.mapKey])
+                .forEach(function (key) {
+                    var map = fileCoverage[keys.mapKey][key];
+                    var hits = fileCoverage[keys.hitsKey];
+
+                    if (keys.mapKey === 'branchMap') {
+                        var locations = map.locations;
+
+                        locations.forEach(function (location, index) {
+                            if (hits[key][index] === 0 && location.skip) {
+                                hits[key][index] = 1;
+                            }
+                        });
+
+                        return;
+                    }
+
+                    if (hits[key] === 0 && map.skip) {
+                        hits[key] = 1;
+                    }
+                });
+            });
+
+        return fileCoverage;
+    }
+
     var exportables = {
         addDerivedInfo: addDerivedInfo,
         addDerivedInfoForFile: addDerivedInfoForFile,
@@ -355,7 +399,8 @@
         summarizeCoverage: summarizeCoverage,
         mergeFileCoverage: mergeFileCoverage,
         mergeSummaryObjects: mergeSummaryObjects,
-        toYUICoverage: toYUICoverage
+        toYUICoverage: toYUICoverage,
+        incrementIgnoredTotals: incrementIgnoredTotals
     };
 
     /* istanbul ignore else: windows */

--- a/lib/report/clover.js
+++ b/lib/report/clover.js
@@ -73,6 +73,8 @@ function branchCoverageByLine(fileCoverage) {
 }
 
 function addClassStats(node, fileCoverage, writer) {
+    fileCoverage = utils.incrementIgnoredTotals(fileCoverage);
+
     var metrics = node.metrics,
         branchByLine = branchCoverageByLine(fileCoverage),
         fnMap,

--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -78,6 +78,8 @@ function branchCoverageByLine(fileCoverage) {
 }
 
 function addClassStats(node, fileCoverage, writer, projectRoot) {
+    fileCoverage = utils.incrementIgnoredTotals(fileCoverage);
+
     var metrics = node.metrics,
         branchByLine = branchCoverageByLine(fileCoverage),
         fnMap,

--- a/test/other/test-object-utils.js
+++ b/test/other/test-object-utils.js
@@ -196,6 +196,46 @@ module.exports = {
 
             test.deepEqual(ret, foo);
             test.done();
+        },
+        "increment ignored totals": {
+            setUp: function (cb) {
+                it = {
+                    l: {},
+                    s: {
+                        1: 0
+                    },
+                    b: {
+                        1: [0, 0]
+                    },
+                    f: {
+                        1: 0
+                    },
+                    statementMap: {
+                        1: {skip: true}
+                    },
+                    branchMap: {
+                        1: {
+                            locations: [
+                                {},
+                                {skip: true}
+                            ]
+                        }
+                    },
+                    fnMap: {
+                        1: {skip: true}
+                    }
+                };
+
+                cb();
+            },
+            "should return file coverage object with incremented hits": function (test) {
+                var result = utils.incrementIgnoredTotals(it);
+                test.equal(1, result.s['1']);
+                test.deepEqual([0, 1], result.b['1']);
+                test.equal(1, result.f['1']);
+                test.done();
+            }
         }
     }
 };
+


### PR DESCRIPTION
Just added `JSON.parse(JSON.stringify(obj));` so we get a clone of the object without a lib.

Enhances #238.