### PR TITLE
Fix badtransformers when extensions are passed to hookRequire

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -99,7 +99,7 @@ function hookRequire(matcher, transformer, options) {
 
     extensions.forEach(function(ext){
         if (!(ext in originalLoaders)) { 
-            originalLoaders[ext] = Module._extensions[ext];
+            originalLoaders[ext] = Module._extensions[ext] || Module._extensions['.js'];
         } 
         Module._extensions[ext] = function (module, filename) {
             var ret = fn(fs.readFileSync(filename, 'utf8'), filename);

--- a/test/other/test-hook.js
+++ b/test/other/test-hook.js
@@ -76,8 +76,6 @@ module.exports = {
     },
     "when extensions are passed to hookRequire": {
         setUp: function(cb) {
-            var extensions = require('module')._extensions;
-            extensions['.es6'] = extensions['.js'];
             hook.hookRequire(matcher2, transformer2, { verbose: true, extensions: ['.es6'] });
             cb();
         },
@@ -99,6 +97,14 @@ module.exports = {
             test.equals('foo', foo.foo());
             test.done();
         },
+        "bad transformer should return original code": function (test) {
+            hook.unhookRequire();
+            hook.hookRequire(matcher2, badTransformer, { verbose: true, extensions: ['.es6'] });
+            var bar = require('./data/bar');
+            test.ok(bar.bar);
+            test.equals('bar', bar.bar());
+            test.done();
+        }
     },
     "when createScript is hooked": {
         setUp: function (cb) {


### PR DESCRIPTION
Right now if you use the requireHook to hook an `ext` that does not have a specific compiler at `Module._extensions[ext]` then `originalLoaders[ext]` will be set to `undefined`.

If the transformer fails when trying to load file with the hooked extension it will try to call `originalLoaders[ext](module, filename)` which will throw an error because `originalLoaders[ext]` will be undefined.

This PR sets `originalLoaders[ext]` to be `Module._extensions['.js']` if there is no specific compiler, which is the default node behavior.