### PR TITLE
updated text reporter so that it displays a list of the lines missing coverage

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -155,6 +155,7 @@
      *          statements: statementMetrics,
      *          functions: functionMetrics,
      *          branches: branchMetrics
+     *          linesCovered: lineCoveredCount
      *      }
      *
      *  Each individual metric object looks as follows:
@@ -194,7 +195,8 @@
                 covered: 0,
                 skipped: 0,
                 pct: 'Unknown'
-            }
+            },
+            linesCovered: {}
         };
     }
     /**
@@ -213,6 +215,7 @@
         ret.functions = computeSimpleTotals(fileCoverage, 'f', 'fnMap');
         ret.statements = computeSimpleTotals(fileCoverage, 's', 'statementMap');
         ret.branches = computeBranchTotals(fileCoverage);
+        ret.linesCovered = fileCoverage.l;
         return ret;
     }
     /**
@@ -268,6 +271,15 @@
                         ret[key].total += obj[key].total;
                         ret[key].covered += obj[key].covered;
                         ret[key].skipped += obj[key].skipped;
+                    });
+
+                    // keep track of all lines we have coverage for.
+                    Object.keys(obj.linesCovered).forEach(function (key) {
+                        if (!ret.linesCovered[key]) {
+                            ret.linesCovered[key] = obj.linesCovered[key];
+                        } else {
+                            ret.linesCovered[key] += obj.linesCovered[key];
+                        }
                     });
                 }
             };
@@ -411,4 +423,3 @@
         window.coverageUtils = exportables;
     }
 }(typeof module !== 'undefined' && typeof module.exports !== 'undefined' && typeof exports !== 'undefined'));
-

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -11,8 +11,9 @@ var path = require('path'),
     Report = require('./index'),
     TreeSummarizer = require('../util/tree-summarizer'),
     utils = require('../object-utils'),
-    PCT_COLS = 10,
-    TAB_SIZE = 3,
+    PCT_COLS = 9,
+    MISSING_COL = 15,
+    TAB_SIZE = 1,
     DELIM = ' |',
     COL_DELIM = '-|';
 
@@ -86,23 +87,39 @@ function formatName(name, maxCols, level, clazz) {
     return fill(name, maxCols, false, level, clazz);
 }
 
-function formatPct(pct, clazz) {
-    return fill(pct, PCT_COLS, true, 0, clazz);
+function formatPct(pct, clazz, width) {
+    return fill(pct, width || PCT_COLS, true, 0, clazz);
 }
 
 function nodeName(node) {
     return node.displayShortName() || 'All files';
 }
 
-
 function tableHeader(maxNameCols) {
     var elements = [];
     elements.push(formatName('File', maxNameCols, 0));
     elements.push(formatPct('% Stmts'));
-    elements.push(formatPct('% Branches'));
+    elements.push(formatPct('% Branch'));
     elements.push(formatPct('% Funcs'));
     elements.push(formatPct('% Lines'));
+    elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
     return elements.join(' |') + ' |';
+}
+
+function collectMissingLines(kind, linesCovered) {
+  var missingLines = [];
+
+  if (kind !== 'file') {
+      return [];
+  }
+
+  Object.keys(linesCovered).forEach(function (key) {
+      if (!linesCovered[key]) {
+          missingLines.push(key);
+      }
+  });
+
+  return missingLines;
 }
 
 function tableRow(node, maxNameCols, level, watermarks) {
@@ -111,6 +128,7 @@ function tableRow(node, maxNameCols, level, watermarks) {
         branches = node.metrics.branches.pct,
         functions = node.metrics.functions.pct,
         lines = node.metrics.lines.pct,
+        missingLines = collectMissingLines(node.kind, node.metrics.linesCovered),
         elements = [];
 
     elements.push(formatName(name, maxNameCols, level, defaults.classFor('statements', node.metrics, watermarks)));
@@ -118,6 +136,7 @@ function tableRow(node, maxNameCols, level, watermarks) {
     elements.push(formatPct(branches, defaults.classFor('branches', node.metrics, watermarks)));
     elements.push(formatPct(functions, defaults.classFor('functions', node.metrics, watermarks)));
     elements.push(formatPct(lines, defaults.classFor('lines', node.metrics, watermarks)));
+    elements.push(formatPct(missingLines.join(','), 'low', MISSING_COL));
 
     return elements.join(DELIM) + DELIM;
 }
@@ -145,6 +164,7 @@ function makeLine(nameWidth) {
     elements.push(pct);
     elements.push(pct);
     elements.push(pct);
+    elements.push(padding(MISSING_COL, '-'));
     return elements.join(COL_DELIM) + COL_DELIM;
 }
 
@@ -180,13 +200,15 @@ Report.mix(TextReport, {
             tree,
             root,
             nameWidth,
-            statsWidth = 4 * ( PCT_COLS + 2),
+            statsWidth = 4 * (PCT_COLS + 2) + MISSING_COL,
             maxRemaining,
             strings = [],
             text;
 
         collector.files().forEach(function (key) {
-            summarizer.addFileCoverageSummary(key, utils.summarizeFileCoverage(collector.fileCoverageFor(key)));
+            summarizer.addFileCoverageSummary(key, utils.summarizeFileCoverage(
+                collector.fileCoverageFor(key)
+            ));
         });
         tree = summarizer.getTreeSummary();
         root = tree.root;

--- a/test/other/test-summarizer.js
+++ b/test/other/test-summarizer.js
@@ -15,19 +15,22 @@ module.exports = {
             statements: { covered: 5, total: 10, pct: 50, skipped: 0 },
             lines: { covered: 5, total: 10, pct: 50, skipped: 0 },
             functions: { covered: 15, total: 20, pct: 75, skipped: 0 },
-            branches: { covered: 100, total: 200, pct: 50, skipped: 0 }
+            branches: { covered: 100, total: 200, pct: 50, skipped: 0 },
+            linesCovered: { '320': 1, '420': 10 }
         };
         s2 = {
             statements: { covered: 10, total: 20, pct: 50, skipped: 0 },
             lines: { covered: 10, total: 20, pct: 50, skipped: 0 },
             functions: { covered: 75, total: 100, pct: 75, skipped: 0 },
-            branches: { covered: 1, total: 2, pct: 50, skipped: 0 }
+            branches: { covered: 1, total: 2, pct: 50, skipped: 0 },
+            linesCovered: { '320': 3, '500': 0 }
         };
         s3 = {
             statements: { covered: 9, total: 10, pct: 90, skipped: 0 },
             lines: { covered: 9, total: 10, pct: 90, skipped: 0 },
             functions: { covered: 15, total: 15, pct: 100, skipped: 0 },
-            branches: { covered: 101, total: 101, pct: 100, skipped: 0 }
+            branches: { covered: 101, total: 101, pct: 100, skipped: 0 },
+            linesCovered: {}
         };
         cb();
     },
@@ -71,6 +74,13 @@ module.exports = {
             test.ok(tree.getNode(path.join('lib', 'foo.js')));
             test.ok(tree.getNode(path.join('lib', 'bar.js')));
             test.ok(tree.getNode(path.join('lib', 'util', 'baz.js')));
+            test.done();
+        },
+        "should combine linesCovered across multiple summary objects": function  (test) {
+            var summary = utils.mergeSummaryObjects(s1, s2);
+            test.equal(4, summary.linesCovered['320']);
+            test.equal(10, summary.linesCovered['420']);
+            test.equal(0, summary.linesCovered['500']);
             test.done();
         }
     },


### PR DESCRIPTION
I've been advocating that we switch our test coverage over to Istanbul at npm. One of the major blockers for @ceejbot is that the `text` summary report doesn't provide any immediately actionable information. 

It's really handy to know the exact lines that are missing coverage, so that you can make fixes, without having to pop open the detailed lcov report in a browser (our text reporter for Blanket has this information)

I've taken a first crack at adding an additional column to the text report that provides this information:

![screen shot 2015-06-20 at 10 59 33 pm](https://cloud.githubusercontent.com/assets/194609/8270191/6448522a-17a1-11e5-8b65-cfa87e924db0.png)

The change was pretty simple: as summary objects are merged with `mergeSummaryObjects`, additional information is now tracked about which lines are covered.

I played with formatting a bit `padding`, `spacing`, etc, to try to keep the total report under 80 columns.
