### PR TITLE
add estraverse as depedency; stay up-to-date with VisitorKeys object

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -3,12 +3,13 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-/*global esprima, escodegen, window */
+/*global esprima, escodegen, estraverse, window */
 (function (isNode) {
     "use strict";
     var SYNTAX,
         nodeType,
         ESP = isNode ? require('esprima') : esprima,
+        ESTRAVERSE = isNode ? require('estraverse') : estraverse,
         ESPGEN = isNode ? require('escodegen') : escodegen,  //TODO - package as dependency
         crypto = isNode ? require('crypto') : null,
         LEADER_WRAP = '(function () { ',
@@ -28,6 +29,7 @@
         preconditions = {
             'Could not find esprima': ESP,
             'Could not find escodegen': ESPGEN,
+            'Could not find estraverse': ESTRAVERSE,
             'JSON object not in scope': JSON,
             'Array does not implement push': [].push,
             'Array does not implement unshift': [].unshift
@@ -65,79 +67,7 @@
         Array.prototype.push.apply(ary, thing);
     }
 
-    SYNTAX = {
-        // keep in sync with estraverse's VisitorKeys
-        AssignmentExpression: ['left', 'right'],
-        AssignmentPattern: ['left', 'right'],
-        ArrayExpression: ['elements'],
-        ArrayPattern: ['elements'],
-        ArrowFunctionExpression: ['params', 'body'],
-        AwaitExpression: ['argument'], // CAUTION: It's deferred to ES7.
-        BlockStatement: ['body'],
-        BinaryExpression: ['left', 'right'],
-        BreakStatement: ['label'],
-        CallExpression: ['callee', 'arguments'],
-        CatchClause: ['param', 'body'],
-        ClassBody: ['body'],
-        ClassDeclaration: ['id', 'superClass', 'body'],
-        ClassExpression: ['id', 'superClass', 'body'],
-        ComprehensionBlock: ['left', 'right'],  // CAUTION: It's deferred to ES7.
-        ComprehensionExpression: ['blocks', 'filter', 'body'],  // CAUTION: It's deferred to ES7.
-        ConditionalExpression: ['test', 'consequent', 'alternate'],
-        ContinueStatement: ['label'],
-        DebuggerStatement: [],
-        DirectiveStatement: [],
-        DoWhileStatement: ['body', 'test'],
-        EmptyStatement: [],
-        ExportAllDeclaration: ['source'],
-        ExportDefaultDeclaration: ['declaration'],
-        ExportNamedDeclaration: ['declaration', 'specifiers', 'source'],
-        ExportSpecifier: ['exported', 'local'],
-        ExpressionStatement: ['expression'],
-        ForStatement: ['init', 'test', 'update', 'body'],
-        ForInStatement: ['left', 'right', 'body'],
-        ForOfStatement: ['left', 'right', 'body'],
-        FunctionDeclaration: ['id', 'params', 'body'],
-        FunctionExpression: ['id', 'params', 'body'],
-        GeneratorExpression: ['blocks', 'filter', 'body'],  // CAUTION: It's deferred to ES7.
-        Identifier: [],
-        IfStatement: ['test', 'consequent', 'alternate'],
-        ImportDeclaration: ['specifiers', 'source'],
-        ImportDefaultSpecifier: ['local'],
-        ImportNamespaceSpecifier: ['local'],
-        ImportSpecifier: ['imported', 'local'],
-        Literal: [],
-        LabeledStatement: ['label', 'body'],
-        LogicalExpression: ['left', 'right'],
-        MemberExpression: ['object', 'property'],
-        MethodDefinition: ['key', 'value'],
-        ModuleSpecifier: [],
-        NewExpression: ['callee', 'arguments'],
-        ObjectExpression: ['properties'],
-        ObjectPattern: ['properties'],
-        Program: ['body'],
-        Property: ['key', 'value'],
-        RestElement: [ 'argument' ],
-        ReturnStatement: ['argument'],
-        SequenceExpression: ['expressions'],
-        SpreadElement: ['argument'],
-        SuperExpression: ['super'],
-        SwitchStatement: ['discriminant', 'cases'],
-        SwitchCase: ['test', 'consequent'],
-        TaggedTemplateExpression: ['tag', 'quasi'],
-        TemplateElement: [],
-        TemplateLiteral: ['quasis', 'expressions'],
-        ThisExpression: [],
-        ThrowStatement: ['argument'],
-        TryStatement: ['block', 'handler', 'finalizer'],
-        UnaryExpression: ['argument'],
-        UpdateExpression: ['argument'],
-        VariableDeclaration: ['declarations'],
-        VariableDeclarator: ['id', 'init'],
-        WhileStatement: ['test', 'body'],
-        WithStatement: ['object', 'body'],
-        YieldExpression: ['argument']
-    };
+    SYNTAX = ESTRAVERSE.VisitorKeys;
 
     for (nodeType in SYNTAX) {
         /* istanbul ignore else: has own property */

--- a/package.json
+++ b/package.json
@@ -85,20 +85,21 @@
     "url": "git://github.com/gotwarlost/istanbul.git"
   },
   "dependencies": {
-    "esprima": "2.4.x",
+    "abbrev": "1.0.x",
+    "async": "1.x",
     "escodegen": "1.6.x",
+    "esprima": "2.4.x",
+    "estraverse": "4.x",
+    "fileset": "0.2.x",
     "handlebars": "3.0.0",
+    "js-yaml": "3.x",
     "mkdirp": "0.5.x",
     "nopt": "3.x",
-    "fileset": "0.2.x",
-    "which": "1.0.x",
-    "async": "1.x",
-    "supports-color": "1.3.x",
-    "abbrev": "1.0.x",
-    "wordwrap": "0.0.x",
+    "once": "1.x",
     "resolve": "1.1.x",
-    "js-yaml": "3.x",
-    "once": "1.x"
+    "supports-color": "1.3.x",
+    "which": "1.0.x",
+    "wordwrap": "0.0.x"
   },
   "devDependencies": {
     "rimraf": "2.2.x",

--- a/test/browser/support/index.html
+++ b/test/browser/support/index.html
@@ -3,9 +3,11 @@
 <head>
 <meta charset='utf-8'>
 <title>Instrumentation test on the browser</title>
+<script src='/_estraverse.js'></script>
 <script src='/_esprima.js'></script>
 <script src='/_escodegen.js'></script>
 <script src='/_instrumenter.js'></script>
+
 <script src="/_yui.js"></script>
 <style type="text/css">
     body { font-family: verdana; font-size: 10pt; margin: 2em; }

--- a/test/browser/support/server.js
+++ b/test/browser/support/server.js
@@ -12,6 +12,7 @@ var handlebars = require('handlebars'),
     },
     esprimaSource = reader('..', '..', '..', 'node_modules', 'esprima', 'esprima.js'),
     escodegenSource = reader('..', '..', '..', 'node_modules', 'escodegen', 'escodegen.browser.min.js'),
+    estraverseSource = reader('..', '..', '..', 'node_modules', 'estraverse', 'dist', 'estraverse.js'),
     yuiSource = reader('vendor', 'yui-support.js'),
     vm = require('vm'),
     server;
@@ -47,6 +48,11 @@ function handleInstrumenter(request, response) {
     } else {
         response.end(instrumenterSource, 'utf8');
     }
+}
+
+function handleEstraverse(request, response) {
+    response.setHeader('content-type', 'application/javascript');
+    response.end(estraverseSource, 'utf8');
 }
 
 function handleFile(request, response) {
@@ -124,6 +130,9 @@ function handler(request, response) {
             break;
         case '/_instrumenter.js':
             handleInstrumenter(request, response);
+            break;
+        case '/_estraverse.js':
+            handleEstraverse(request, response);
             break;
         default:
             handleFile(request, response);


### PR DESCRIPTION
Notes:

- Because the `SYNTAX` object in `instrumenter.js` was getting out-of-sync with `estraverse`, it is an obvious maintenance burden.
- This PR eliminates that particular burden.
- `estraverse` won't actually run in the browser.  estools/estraverse#52 addresses that issue.  **I wouldn't recommend merging this PR until that one is merged**, unless you want to use my fork.
- You can skirt around the issue by modifying `index.html` to do something like this:
  
  ```js
  <script>
    // hack around estraverse
    window.exports = {};
    window.require = function() { return {}; };
  </script>
  <script src='/_estraverse.js'></script>
  <script>
      // cleanup aforementioned hack
      window.estraverse = window.exports;
      delete window.exports;
      delete window.require;
  </script>
  ```
- There's some test failure regarding `prettify.js`; I don't *think* this is related, but I could be wrong.