### PR TITLE
Changed the cobertura dtd url from sourceforge to github.

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -12,7 +12,7 @@ var path = require('path'),
 
 /**
  * a `Report` implementation that produces a cobertura-style XML file that conforms to the
- * http://cobertura.sourceforge.net/xml/coverage-04.dtd DTD.
+ * https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd DTD.
  *
  * Usage
  * -----
@@ -148,7 +148,7 @@ function walk(node, collector, writer, level, projectRoot) {
     if (level === 0) {
         metrics = node.metrics;
         writer.println('<?xml version="1.0" ?>');
-        writer.println('<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">');
+        writer.println('<!DOCTYPE coverage SYSTEM "https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd">');
         writer.println('<coverage' +
             attr('lines-valid', metrics.lines.total) +
             attr('lines-covered', metrics.lines.covered) +

--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -148,7 +148,8 @@ function walk(node, collector, writer, level, projectRoot) {
     if (level === 0) {
         metrics = node.metrics;
         writer.println('<?xml version="1.0" ?>');
-        writer.println('<!DOCTYPE coverage SYSTEM "https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd">');
+        writer.println('<!DOCTYPE coverage SYSTEM ' +
+            '"https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd">');
         writer.println('<coverage' +
             attr('lines-valid', metrics.lines.total) +
             attr('lines-covered', metrics.lines.covered) +


### PR DESCRIPTION
For the last few days, sourceforge.net has been returning a `temporarily in static offline mode` error when retrieving: http://cobertura.sourceforge.net/xml/coverage-04.dtd. This is a known problem which is being fixed upstream in the cobertura project here: https://github.com/cobertura/cobertura/issues/38. That issue is where I got the github url for this pull request.

Note that without this fix, running tests with istanbul returns a test failure for `coverage.xml<init>`.