### PR TITLE
Replaced deprecated util.puts with console.log

### DIFF
--- a/lib/command/instrument.js
+++ b/lib/command/instrument.js
@@ -223,7 +223,7 @@ Command.mix(InstrumentCommand, {
             mkdirp.sync(path.dirname(baselineFile));
             instrumenter = new BaselineCollector(instrumenter);
             process.on('exit', function () {
-                util.puts('Saving baseline coverage at: ' + baselineFile);
+                console.log('Saving baseline coverage at: ' + baselineFile);
                 fs.writeFileSync(baselineFile, JSON.stringify(instrumenter.getCoverage()), 'utf8');
             });
         }


### PR DESCRIPTION
[Documenation lists util.puts as deprecated](https://nodejs.org/api/util.html), every usage outputs following message: 

> util.puts: Use console.log instead