### PR TITLE
Update esprima to 2.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "url": "git://github.com/gotwarlost/istanbul.git"
   },
   "dependencies": {
-    "esprima": "2.4.x",
+    "esprima": "2.5.x",
     "escodegen": "1.6.x",
     "handlebars": "3.0.0",
     "mkdirp": "0.5.x",


### PR DESCRIPTION
Why I need this: I have code like this:
```js
function* foo() {
  return {
    bar: yield baz()
  };
}
```
I guess `2.4.x` version of esprima fail while it's parsing this code.