### PR TITLE
Improve source map support

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -51,6 +51,7 @@ function run(args, commandName, enableHooks, callback) {
             dir: path,
             verbose: Boolean,
             yui: Boolean,
+            'source-map': Boolean,
             'default-excludes': Boolean,
             print: String,
             'self-test': Boolean,
@@ -71,7 +72,8 @@ function run(args, commandName, enableHooks, callback) {
                 excludes: opts.x,
                 'include-all-sources': opts['include-all-sources'],
                 'preload-sources': opts['preload-sources'],
-                'include-pid': opts['include-pid']
+                'include-pid': opts['include-pid'],
+                'source-map': opts['source-map']
             },
             reporting: {
                 reports: opts.report,
@@ -156,11 +158,19 @@ function run(args, commandName, enableHooks, callback) {
                 if (err) { return callback(err); }
 
                 var coverageVar = '$$cov_' + new Date().getTime() + '$$',
-                    instrumenter = new Instrumenter({ coverageVariable: coverageVar , preserveComments: preserveComments}),
+                    instrumenter = new Instrumenter({
+                        coverageVariable: coverageVar,
+                        preserveComments: preserveComments,
+                        sourceMap: opts['source-map']
+                    }),
                     transformer = instrumenter.instrumentSync.bind(instrumenter),
                     hookOpts = { verbose: verbose, extensions: config.instrumentation.extensions() },
                     postRequireHook = config.hooks.postRequireHook(),
                     postLoadHookFile;
+
+                if (opts['source-map']) {
+                    transformer = require('../../util/source-map-support')(transformer, instrumenter);
+                }
 
                 if (postRequireHook) {
                     postLoadHookFile = path.resolve(postRequireHook);

--- a/lib/command/instrument.js
+++ b/lib/command/instrument.js
@@ -220,7 +220,8 @@ Command.mix(InstrumentCommand, {
             embedSource: iOpts.embedSource(),
             noCompact: !iOpts.compact(),
             preserveComments: iOpts.preserveComments(),
-            esModules: iOpts.esModules()
+            esModules: iOpts.esModules(),
+            sourceMap: iOpts.sourceMap()
         });
 
         if (needBaseline) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ function defaultConfig(includeBackCompatAttrs) {
             variable: '__coverage__',
             compact: true,
             'preserve-comments': false,
+            'source-map': false,
             'complete-copy': false,
             'save-baseline': false,
             'baseline-file': './coverage/coverage-baseline.json',
@@ -187,13 +188,18 @@ function InstrumentOptions(config) {
  * @method includePid
  * @return {Boolean} true to include pid in coverage filename.
  */
+/**
+ * returns if the inline source maps should be generated when instrumenting code.
+ * @method sourceMap
+ * @return {Boolean} true to generate inline source map comment.
+ */
 
 
 addMethods(InstrumentOptions,
     'extensions', 'defaultExcludes', 'completeCopy',
     'embedSource', 'variable', 'compact', 'preserveComments',
     'saveBaseline', 'baselineFile', 'esModules',
-    'includeAllSources', 'includePid');
+    'includeAllSources', 'includePid', 'sourceMap');
 
 /**
  * returns the root directory used by istanbul which is typically the root of the

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -11,6 +11,8 @@
         ESP = isNode ? require('esprima') : esprima,
         ESPGEN = isNode ? require('escodegen') : escodegen,  //TODO - package as dependency
         crypto = isNode ? require('crypto') : null,
+        convertSourceMap = isNode ? require('convert-source-map') : null,
+        SourceMapConsumer = isNode ? require('source-map').SourceMapConsumer : null,
         LEADER_WRAP = '(function () { ',
         TRAILER_WRAP = '\n}());',
         COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/,
@@ -384,7 +386,8 @@
             noCompact: false,
             embedSource: false,
             preserveComments: false,
-            esModules: false
+            esModules: false,
+            sourceMap: false
         };
 
         if (this.opts.esModules && !this.opts.noAutoWrap) {
@@ -553,12 +556,19 @@
             }
             this.walker.startWalk(program);
             codegenOptions = this.opts.codeGenerationOptions || { format: { compact: !this.opts.noCompact }};
+            if (!('sourceMap' in codegenOptions) && this.opts.sourceMap) {
+                // We need to provide our own file name to ensure that any remaps below as well as the
+                // source-map-support implementations line up.
+                codegenOptions.sourceMap = filename;
+                codegenOptions.sourceMapWithCode = true;
+            }
             codegenOptions.comment = this.opts.preserveComments;
             //console.log(JSON.stringify(program, undefined, 2));
 
             generated = ESPGEN.generate(program, codegenOptions);
             preamble = this.getPreamble(originalCode || '', usingStrict);
 
+            var sourceMapComment = '';
             if (generated.map && generated.code) {
                 lineCount = preamble.split(/\r\n|\r|\n/).length;
                 // offset all the generated line numbers by the number of lines in the preamble
@@ -567,9 +577,17 @@
                 }
                 this.sourceMap = generated.map;
                 generated = generated.code;
+
+                if (isNode && originalCode) {
+                    var originalSourceMap = convertSourceMap.fromSource(originalCode);
+                    if (originalSourceMap) {
+                        this.sourceMap.applySourceMap(new SourceMapConsumer(originalSourceMap.toObject()), filename);
+                    }
+                    sourceMapComment = '\n' + convertSourceMap.fromObject(this.sourceMap.toJSON()).toComment();
+                }
             }
 
-            return preamble + '\n' + generated + '\n';
+            return preamble + '\n' + generated + sourceMapComment + '\n';
         },
         /**
          * Callback based instrumentation. Note that this still executes synchronously in the same process tick

--- a/lib/util/source-map-support.js
+++ b/lib/util/source-map-support.js
@@ -1,0 +1,26 @@
+var sourceMapSupport = require('source-map-support');
+
+var sourceMaps = {};
+
+// Implements a post-load hook that makes our generated files available to source-map-lookup
+//
+// Inspired by https://github.com/babel/babel/blob/master/packages/babel/src/api/register/node.js#L15
+module.exports = function(transformer, instrumenter) {
+  sourceMapSupport.install({
+    handleUncaughtExceptions: false,
+    retrieveSourceMap: function(filename) {
+      var map = sourceMaps[filename];
+      if (map) {
+        return {
+          map: map
+        };
+      }
+    }
+  });
+
+  return function(code, filename) {
+    var ret = transformer(code, filename);
+    sourceMaps[filename] = instrumenter.lastSourceMap().toJSON();
+    return ret;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "dependencies": {
     "abbrev": "1.0.x",
     "async": "1.x",
+    "convert-source-map": "^1.1.1",
     "escodegen": "1.7.x",
     "esprima": "2.5.x",
     "fileset": "0.2.x",
@@ -105,6 +106,8 @@
     "nopt": "3.x",
     "once": "1.x",
     "resolve": "1.1.x",
+    "source-map": "^0.4.4",
+    "source-map-support": "^0.3.2",
     "supports-color": "^3.1.0",
     "which": "^1.1.1",
     "wordwrap": "^1.0.0"

--- a/test/instrumentation/test-misc.js
+++ b/test/instrumentation/test-misc.js
@@ -57,6 +57,18 @@ module.exports = {
                 test.fail('instrumentation should have succeeded but did not');
             }
             test.done();
+        },
+        "inlne source maps are included in the output when specified": function (test) {
+            try {
+                instrumenter.opts.sourceMap = true;
+                test.ok(/sourceMappingURL=data:application\/json/.test(instrumenter.instrumentSync('var foo = { a: 1 };')));
+
+                instrumenter.opts.sourceMap = false;
+                test.ok(!/sourceMappingURL=data:application\/json/.test(instrumenter.instrumentSync('var foo = { a: 1 };')));
+            } catch (ex) {
+                test.fail('instrumentation should have succeeded but did not');
+            }
+            test.done();
         }
     }
 };


### PR DESCRIPTION
Attempt to resolve #274.

This adds a couple of different features:
1. Source maps are now aware of existing source maps and will merge these with the istanbul generated source map.
2. Adds option to include source maps inline in the instrumented output.
3. Adds source map error support under node when using run-with-cover.

Net effect is this:

```
  1) parser parsers partial blocks:
     TypeError: Cannot read property 'line' of undefined
      at Object.prepareProgram (./dist/cjs/handlebars/compiler/helpers.js:9:8043)
      at Object.anonymous (./dist/cjs/handlebars/compiler/parser.js:9:3727)
      at Object.parse (./dist/cjs/handlebars/compiler/parser.js:9:37453)
      at HandlebarsEnvironment.parse (./dist/cjs/handlebars/compiler/base.js:9:3159)
      at astFor (./spec/parser.js:7:26)
      at Context.<anonymous> (./spec/parser.js:117:12)
```

From this:

```
  1) parser parsers partial blocks:
     TypeError: Cannot read property 'line' of undefined
      at Object.prepareProgram (lib/handlebars/compiler/helpers.js:135:17)
      at Object.anonymous (lib/handlebars/compiler/parser.js:16:20)
      at Object.parse (lib/handlebars/compiler/parser.js:263:36)
      at HandlebarsEnvironment.parse (./dist/cjs/handlebars/compiler/base.js:9:3159)
      at astFor (./spec/parser.js:7:26)
      at Context.<anonymous> (./spec/parser.js:117:12)
```

This could use additional test coverage for the source-map-support integration, but I wanted to get this out there for feedback before investing too much time in that implementation.
