### PR TITLE
Improve readability via better lineHeight

### DIFF
--- a/lib/assets/base.css
+++ b/lib/assets/base.css
@@ -39,7 +39,7 @@ pre {
     font-family: Consolas, Menlo, Monaco, monospace;
     margin: 0;
     padding: 0;
-    line-height: 14px;
+    line-height: 1.3;
     font-size: 14px;
     -moz-tab-size: 2;
     -o-tab-size:  2;


### PR DESCRIPTION
Before:  

![screenshot from 2015-08-17 14 29 04](https://cloud.githubusercontent.com/assets/713283/9304912/25e33efe-44ed-11e5-91f2-7999bc683dca.png)

After:

![screenshot from 2015-08-17 14 29 22](https://cloud.githubusercontent.com/assets/713283/9304916/2e97742a-44ed-11e5-9c12-12f7faa2bb38.png)

The **g** in `performance.getEntriesByName` was hard to read, the line height fix that.