### PR TITLE
Fix #426

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -239,6 +239,8 @@
                               pushAll(childArray, assignNode.prepend);
                               delete assignNode.prepend;
                           }
+                        } else {
+                            assignNode = undefined;
                         }
                         pushAll(childArray, assignNode);
                     }

--- a/test/instrumentation/test-expressions.js
+++ b/test/instrumentation/test-expressions.js
@@ -54,15 +54,15 @@ module.exports = {
     "with an array expression with empty positions": {
         setUp: function (cb) {
             code = [
-                'var x = [, , args[0], ];',
-                'output = x.indexOf(args[0]) === x.length - 1;'
+                'var x = [args[0], , args[1], ];',
+                'output = x.indexOf(args[1]) === x.length - 1 && x[0] !== x[1];'
             ];
             verifier = helper.verifier(__filename, code);
             cb();
         },
 
         "should not barf in any way": function (test) {
-            verifier.verify(test, [ 5 ], true, { lines: { 1: 1, 2: 1 }, branches: {}, functions: {}, statements: { '1': 1, '2': 1 } });
+            verifier.verify(test, [ 1, 5 ], true, { lines: { 1: 1, 2: 1 }, branches: { 1: [ 1, 1 ]}, functions: {}, statements: { '1': 1, '2': 1 } });
             test.done();
         }
     }


### PR DESCRIPTION
[https://github.com/gotwarlost/istanbul/issues/426](https://github.com/gotwarlost/istanbul/issues/426)

Shout if you would prefer this PR to set `assignNode` to null, or to set `assignNode` at the top of the iteration rather than in the `childElement` conditional.

Also this piggypacks a bit on top of an existing test (_with an array expression with empty positions_). The addition checks for equality between a non-empty array element and a following empty array element. Let me know if there is another way you would like the test formatted.