### PR TITLE
Update outdated / insecure dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://secure.travis-ci.org/gotwarlost/istanbul.png)](http://travis-ci.org/gotwarlost/istanbul)
 [![Dependency Status](https://gemnasium.com/gotwarlost/istanbul.png)](https://gemnasium.com/gotwarlost/istanbul)
 [![Coverage Status](https://img.shields.io/coveralls/gotwarlost/istanbul.svg)](https://coveralls.io/r/gotwarlost/istanbul?branch=master)
+[![bitHound Score](https://www.bithound.io/github/gotwarlost/istanbul/badges/score.svg)](https://www.bithound.io/github/gotwarlost/istanbul)
 
 [![NPM](https://nodei.co/npm/istanbul.png?downloads=true)](https://nodei.co/npm/istanbul/)
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {
-    "rimraf": "2.2.x",
+    "rimraf": "^2.4.3",
     "nodeunit": "0.9.x",
     "jshint": "2.5.x",
     "requirejs": "2.x",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "devDependencies": {
     "coveralls": "2.x",
-    "glob": "4.4.x",
+    "glob": "^5.0.14",
     "jshint": "^2.8.0",
     "nodeunit": "0.9.x",
     "requirejs": "2.x",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "nopt": "3.x",
     "once": "1.x",
     "resolve": "1.1.x",
-    "supports-color": "1.3.x",
+    "supports-color": "^3.1.0",
     "which": "^1.1.1",
     "wordwrap": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -87,20 +87,20 @@
     "url": "git://github.com/gotwarlost/istanbul.git"
   },
   "dependencies": {
-    "esprima": "2.5.x",
+    "abbrev": "1.0.x",
+    "async": "1.x",
     "escodegen": "1.6.x",
-    "handlebars": "3.0.0",
+    "esprima": "2.5.x",
+    "fileset": "0.2.x",
+    "handlebars": "^3.0.3",
+    "js-yaml": "3.x",
     "mkdirp": "0.5.x",
     "nopt": "3.x",
-    "fileset": "0.2.x",
-    "which": "1.0.x",
-    "async": "1.x",
-    "supports-color": "1.3.x",
-    "abbrev": "1.0.x",
-    "wordwrap": "0.0.x",
+    "once": "1.x",
     "resolve": "1.1.x",
-    "js-yaml": "3.x",
-    "once": "1.x"
+    "supports-color": "1.3.x",
+    "which": "1.0.x",
+    "wordwrap": "0.0.x"
   },
   "devDependencies": {
     "rimraf": "2.2.x",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "once": "1.x",
     "resolve": "1.1.x",
     "supports-color": "1.3.x",
-    "which": "1.0.x",
+    "which": "^1.1.1",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -103,11 +103,11 @@
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {
-    "rimraf": "^2.4.3",
-    "nodeunit": "0.9.x",
-    "jshint": "2.5.x",
-    "requirejs": "2.x",
     "coveralls": "2.x",
-    "glob": "4.4.x"
+    "glob": "4.4.x",
+    "jshint": "^2.8.0",
+    "nodeunit": "0.9.x",
+    "requirejs": "2.x",
+    "rimraf": "^2.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "resolve": "1.1.x",
     "supports-color": "1.3.x",
     "which": "1.0.x",
-    "wordwrap": "0.0.x"
+    "wordwrap": "^1.0.0"
   },
   "devDependencies": {
     "rimraf": "2.2.x",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "escodegen": "1.6.x",
     "esprima": "2.5.x",
     "fileset": "0.2.x",
-    "handlebars": "^3.0.3",
+    "handlebars": "^4.0.1",
     "js-yaml": "3.x",
     "mkdirp": "0.5.x",
     "nopt": "3.x",


### PR DESCRIPTION
We’ve discovered several insecure (and outdated) NPM modules in this project. You can see the justification for this PR here: https://www.bithound.io/github/gotwarlost/istanbul

To see the updated score you can visit https://www.bithound.io/github/gtanner/istanbul.

Updated the following outdated NPM modules

- handlebars
- wordwrap
- which
- supports-color
- rimraf
- jshint
- glob

note:

- [x] All test pass
- [x] Added bitHound score badge

The insecure requirement of handlebars will be fixed in the next version: https://github.com/wycats/handlebars.js/issues/1086.

The insecure badge on nodeunit is due to sub dependencies and will be updated in a future PR.

I think the 'unused' badge on supports-color is a bug in bitHound since it is used, I will see if I can get that cleaned up for you as well.

