### PR TITLE
Add support for instrumenting code with es modules

### DIFF
--- a/lib/command/instrument.js
+++ b/lib/command/instrument.js
@@ -152,7 +152,8 @@ Command.mix(InstrumentCommand, {
                 formatOption('--[no-]preserve-comments', 'remove / preserve comments in the output, defaults to false'),
                 formatOption('--[no-]complete-copy', 'also copy non-javascript files to the ouput directory as is, defaults to false'),
                 formatOption('--save-baseline', 'produce a baseline coverage.json file out of all files instrumented'),
-                formatOption('--baseline-file <file>', 'filename of baseline file, defaults to coverage/coverage-baseline.json')
+                formatOption('--baseline-file <file>', 'filename of baseline file, defaults to coverage/coverage-baseline.json'),
+                formatOption('--es-modules', 'source code uses es import/export module syntax')
             ].join('\n\n') + '\n');
         console.error('\n');
     },
@@ -170,7 +171,8 @@ Command.mix(InstrumentCommand, {
                 'save-baseline': Boolean,
                 'baseline-file': path,
                 'embed-source': Boolean,
-                'preserve-comments': Boolean
+                'preserve-comments': Boolean,
+                'es-modules': Boolean
             },
             opts = nopt(template, { v : '--verbose' }, args, 0),
             overrides = {
@@ -183,7 +185,8 @@ Command.mix(InstrumentCommand, {
                     excludes: opts.x,
                     'complete-copy': opts['complete-copy'],
                     'save-baseline': opts['save-baseline'],
-                    'baseline-file': opts['baseline-file']
+                    'baseline-file': opts['baseline-file'],
+                    'es-modules': opts['es-modules']
                 }
             },
             config = configuration.loadFile(opts.config, overrides),
@@ -216,7 +219,8 @@ Command.mix(InstrumentCommand, {
             coverageVariable: iOpts.variable(),
             embedSource: iOpts.embedSource(),
             noCompact: !iOpts.compact(),
-            preserveComments: iOpts.preserveComments()
+            preserveComments: iOpts.preserveComments(),
+            esModules: iOpts.esModules()
         });
 
         if (needBaseline) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,8 @@ function defaultConfig(includeBackCompatAttrs) {
             'save-baseline': false,
             'baseline-file': './coverage/coverage-baseline.json',
             'include-all-sources': false,
-            'include-pid': false
+            'include-pid': false,
+            'es-modules': false
         },
         reporting: {
             print: 'summary',
@@ -177,6 +178,11 @@ function InstrumentOptions(config) {
  * @return {String} the name of the baseline coverage file.
  */
 /**
+ * returns if comments the JS to instrument contains es6 Module syntax.
+ * @method esModules
+ * @return {Boolean} true if code contains es6 import/export statements.
+ */
+/**
  * returns if the coverage filename should include the PID. Used by the  `instrument` command.
  * @method includePid
  * @return {Boolean} true to include pid in coverage filename.
@@ -186,7 +192,7 @@ function InstrumentOptions(config) {
 addMethods(InstrumentOptions,
     'extensions', 'defaultExcludes', 'completeCopy',
     'embedSource', 'variable', 'compact', 'preserveComments',
-    'saveBaseline', 'baselineFile',
+    'saveBaseline', 'baselineFile', 'esModules',
     'includeAllSources', 'includePid');
 
 /**

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -354,6 +354,8 @@
      *      file as an array in the file coverage object for that file. Defaults to `false`
      * @param {Boolean} [options.preserveComments] whether comments should be preserved in the output. Defaults to `false`
      * @param {Boolean} [options.noCompact] emit readable code when set. Defaults to `false`
+     * @param {Boolean} [options.esModules] whether the code to instrument contains uses es
+     *      imports or exports.
      * @param {Boolean} [options.noAutoWrap] do not automatically wrap the source in
      *      an anonymous function before covering it. By default, code is wrapped in
      *      an anonymous function before it is parsed. This is done because
@@ -381,8 +383,16 @@
             noAutoWrap: false,
             noCompact: false,
             embedSource: false,
-            preserveComments: false
+            preserveComments: false,
+            esModules: false
         };
+
+        if (this.opts.esModules && !this.opts.noAutoWrap) {
+            this.opts.noAutoWrap = true;
+            if (this.opts.debug) {
+                console.log('Setting noAutoWrap to true as required by esModules');
+            }
+        }
 
         this.walker = new Walker({
             ArrowFunctionExpression: [ this.arrowBlockConverter ],
@@ -442,7 +452,8 @@
                 loc: true,
                 range: true,
                 tokens: this.opts.preserveComments,
-                comment: true
+                comment: true,
+                sourceType: this.opts.esModules ? 'module' : 'script'
             });
             if (this.opts.preserveComments) {
                 program = ESPGEN.attachComments(program, program.comments, program.tokens);

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "abbrev": "1.0.x",
     "async": "1.x",
-    "escodegen": "1.6.x",
+    "escodegen": "1.7.x",
     "esprima": "2.5.x",
     "fileset": "0.2.x",
     "handlebars": "^4.0.1",

--- a/test/cli/sample-project/lib/util/es-module.js
+++ b/test/cli/sample-project/lib/util/es-module.js
@@ -1,0 +1,5 @@
+import foo from 'foo';
+
+export default function bar() {
+   return foo();
+};

--- a/test/cli/test-cover-command.js
+++ b/test/cli/test-cover-command.js
@@ -57,7 +57,7 @@ module.exports = {
     },
     "should include all files after running tests": function (test) {
         helper.setOpts({ lazyHook : true });
-        run([ 'test/run.js', '0', '-v', '--include-all-sources', '-x', 'lib/util/bad.js' ], function (results) {
+        run([ 'test/run.js', '0', '-v', '--include-all-sources', '-x', 'lib/util/bad.js', '-x', 'lib/util/es-module.js' ], function (results) {
             test.ok(results.succeeded());
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov.info')));
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));
@@ -80,7 +80,7 @@ module.exports = {
     },
     "should include all files after running tests in back-compat mode": function (test) {
         helper.setOpts({ lazyHook : true });
-        run([ 'test/run.js', '0', '-v', '--preload-sources', '-x', 'lib/util/bad.js' ], function (results) {
+        run([ 'test/run.js', '0', '-v', '--preload-sources', '-x', 'lib/util/bad.js', '-x', 'lib/util/es-module.js' ], function (results) {
             test.ok(results.succeeded());
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov.info')));
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'lcov-report')));

--- a/test/cli/test-instrument-command.js
+++ b/test/cli/test-instrument-command.js
@@ -10,7 +10,6 @@ var path = require('path'),
     COMMAND = 'instrument',
     DIR = path.resolve(__dirname, 'sample-project'),
     helper = require('../cli-helper'),
-    existsSync = fs.existsSync || path.existsSync,
     run = helper.runCommand.bind(null, COMMAND),
     INPUT_DIR_JS_FILE_COUNT = 0;
 
@@ -74,7 +73,7 @@ module.exports = {
         });
     },
     "should instrument multiple files": function (test) {
-        run([ 'lib', '--output', OUTPUT_DIR, '-v' ], function (results) {
+        run([ 'lib', '--output', OUTPUT_DIR, '-v', '-x', 'util/es-module.js' ], function (results) {
             test.ok(results.succeeded());
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'foo.js')));
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'bar.js')));
@@ -88,7 +87,7 @@ module.exports = {
         });
     },
     "should instrument multiple files without errors": function (test) {
-        run([ 'lib', '--output', OUTPUT_DIR, '-x', '**/bad.js' ], function (results) {
+        run([ 'lib', '--output', OUTPUT_DIR, '-x', '**/bad.js', '-x', 'util/es-module.js' ], function (results) {
             test.ok(results.succeeded());
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'foo.js')));
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'bar.js')));
@@ -171,6 +170,12 @@ module.exports = {
             test.ok(results.succeeded());
             test.equal(fs.readdirSync(OUTPUT_DIR).length, inputFileCount);
             test.ok(existsSync(path.resolve(OUTPUT_DIR, 'subdir', 'x.css')));
+            test.done();
+        });
+    },
+    "should instrument es modules": function(test) {
+        run([ 'lib/util/es-module.js', '--es-modules'], function (results) {
+            test.ok(results.succeeded());
             test.done();
         });
     }

--- a/test/es6.js
+++ b/test/es6.js
@@ -35,5 +35,13 @@ module.exports = {
 
     isArrowFnAvailable: function () {
         return tryThis('[1 ,2, 3].map(x => x * x)', 'arrow function');
+    },
+
+    isImportAvailable: function () {
+        return tryThis('import fs from "fs"', 'import');
+    },
+
+    isExportAvailable: function () {
+        return tryThis('export default function foo() {}', 'export');
     }
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -89,7 +89,8 @@ function setup(file, codeArray, opts) {
             noAutoWrap: opts.noAutoWrap,
             coverageVariable: coverageVariable,
             embedSource: ps,
-            preserveComments: pc
+            preserveComments: pc,
+            esModules: opts.esModules
         }),
         args = [ codeArray.join("\n")],
         callback = function (err, generated) {

--- a/test/instrumentation/test-es6-export.js
+++ b/test/instrumentation/test-es6-export.js
@@ -1,0 +1,26 @@
+/*jslint nomen: true */
+var helper = require('../helper'),
+   code,
+   verifier;
+
+if (require('../es6').isExportAvailable()) {
+    module.exports = {
+        'should cover export statements': function (test) {
+            code = [
+                'export function bar() { return 2 }',
+                'output = bar()'
+            ];
+            verifier = helper.verifier(__filename, code, {
+                esModules: true,
+                noAutoWrap: true
+            });
+            verifier.verify(test, [], 2, {
+                lines: {'1': 1, '2': 1},
+                branches: {},
+                functions: {'1': 1},
+                statements: {'1': 1, '2': 1, '3': 1}
+            });
+            test.done();
+        }
+    };
+}

--- a/test/instrumentation/test-es6-import.js
+++ b/test/instrumentation/test-es6-import.js
@@ -1,0 +1,26 @@
+/*jslint nomen: true */
+var helper = require('../helper'),
+   code,
+   verifier;
+
+if (require('../es6').isImportAvailable()) {
+    module.exports = {
+        'should cover import statements': function (test) {
+            code = [
+                'import util from "util";',
+                'output = util.format(args[0], args[1]);'
+            ];
+            verifier = helper.verifier(__filename, code, {
+                esModules: true,
+                noAutoWrap: true
+            });
+            verifier.verify(test, ['foo:%s', 'bar'], 'foo:bar', {
+                lines: {'2': 1},
+                branches: {},
+                functions: {},
+                statements: {'1': 1}
+            });
+            test.done();
+        }
+    };
+}


### PR DESCRIPTION
- Add support for instrumenting code that contains es import and export statements.
- Also transpiling es6 in tests so they can be run on node versions that don't support those features