### PR TITLE
The loading config file message on the console is now tied to the verbose state.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -422,7 +422,9 @@ function loadFile(file, overrides) {
     }
 
     if (file) {
-        console.error('Loading config: ' + file);
+        if (overrides && overrides.verbose === true) {
+            console.error('Loading config: ' + file);
+        }
         configObject = file.match(YML_PATTERN) ?
             yaml.safeLoad(fs.readFileSync(file, 'utf8'), { filename: file }) :
             require(path.resolve(file));


### PR DESCRIPTION
Small update to ensure the loading config message, appearing on the console when using the --config arguments, only appears if the --verbose parameter has been specified.
