### PR TITLE
Support in-process transpiling of code

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -17,7 +17,8 @@ var Module = require('module'),
     hook = require('../../hook'),
     Reporter = require('../../reporter'),
     resolve = require('resolve'),
-    configuration = require('../../config');
+    configuration = require('../../config'),
+    MemoryStore = require('../../store/memory');
 
 function usage(arg0, command) {
 
@@ -95,7 +96,8 @@ function run(args, commandName, enableHooks, callback) {
         cmd,
         cmdArgs,
         reportingDir,
-        reporter = new Reporter(config),
+        sourceStore = new MemoryStore(),
+        reporter = new Reporter(config, null, sourceStore),
         runFn,
         excludes;
 
@@ -160,10 +162,16 @@ function run(args, commandName, enableHooks, callback) {
 
                 var coverageVar = '$$cov_' + new Date().getTime() + '$$',
                     instrumenter = new Instrumenter({ coverageVariable: coverageVar , preserveComments: preserveComments}),
-                    transformer = instrumenter.instrumentSync.bind(instrumenter),
                     hookOpts = { verbose: verbose, extensions: config.instrumentation.extensions() },
                     postRequireHook = config.hooks.postRequireHook(),
                     postLoadHookFile;
+
+                // Store files in memory for reporting before instrumenting.
+                function transformer (code, filename) {
+                    sourceStore.set(filename, code);
+
+                    return instrumenter.instrumentSync(code, filename);
+                }
 
                 if (postRequireHook) {
                     postLoadHookFile = path.resolve(postRequireHook);

--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -27,6 +27,7 @@ function usage(arg0, command) {
             formatOption('--root <path> ', 'the root path to look for files to instrument, defaults to .'),
             formatOption('-x <exclude-pattern> [-x <exclude-pattern>]', 'one or more fileset patterns e.g. "**/vendor/**"'),
             formatOption('-i <include-pattern> [-i <include-pattern>]', 'one or more fileset patterns e.g. "**/*.js"'),
+            formatOption('-e <extension> [-e <extension>]', 'one or more extensions e.g. ".js"'),
             formatOption('--[no-]default-excludes', 'apply default excludes [ **/node_modules/**, **/test/**, **/tests/** ], defaults to true'),
             formatOption('--hook-run-in-context', 'hook vm.runInThisContext in addition to require (supports RequireJS), defaults to false'),
             formatOption('--post-require-hook <file> | <module>', 'JS module that exports a function for post-require processing'),
@@ -47,6 +48,7 @@ function run(args, commandName, enableHooks, callback) {
             config: path,
             root: path,
             x: [ Array, String ],
+            e: [ Array, String ],
             report: [Array, String ],
             dir: path,
             verbose: Boolean,
@@ -69,6 +71,7 @@ function run(args, commandName, enableHooks, callback) {
                 root: opts.root,
                 'default-excludes': opts['default-excludes'],
                 excludes: opts.x,
+                extensions: opts.e,
                 'include-all-sources': opts['include-all-sources'],
                 'preload-sources': opts['preload-sources'],
                 'include-pid': opts['include-pid']

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -32,7 +32,6 @@
  * @module main
  */
 var path = require('path'),
-    fs = require('fs'),
     Module = require('module'),
     vm = require('vm'),
     originalLoaders = {},
@@ -98,19 +97,23 @@ function hookRequire(matcher, transformer, options) {
     extensions = options.extensions || ['.js'];
 
     extensions.forEach(function(ext){
-        if (!(ext in originalLoaders)) { 
+        if (!(ext in originalLoaders)) {
             originalLoaders[ext] = Module._extensions[ext] || Module._extensions['.js'];
-        } 
+        }
         Module._extensions[ext] = function (module, filename) {
-            var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
-            if (ret.changed) {
-                module._compile(ret.code, filename);
-            } else {
-                originalLoaders[ext](module, filename);
-            }
-            if (postLoadHook) {
-                postLoadHook(filename);
-            }
+            var _compile = module._compile;
+
+            module._compile = function (code, filename) {
+                var ret = fn(code, filename);
+
+                if (postLoadHook) {
+                    postLoadHook(filename);
+                }
+
+                return _compile.call(module, ret.code, filename);
+            };
+
+            originalLoaders[ext](module, filename);
         };
     });
 }
@@ -194,5 +197,3 @@ module.exports = {
     unhookRunInThisContext : unhookRunInThisContext,
     unloadRequireCache: unloadRequireCache
 };
-
-

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -30,9 +30,10 @@ var Report = require('./report'),
  * @constructor
  * @module main
  */
-function Reporter(cfg, dir) {
+function Reporter(cfg, dir, sourceStore) {
     this.config = cfg || configuration.loadFile();
     this.dir = dir || this.config.reporting.dir();
+    this.sourceStore = sourceStore;
     this.reports = {};
 }
 
@@ -51,6 +52,7 @@ Reporter.prototype = {
             rptConfig = config.reporting.reportConfig()[fmt] || {};
         rptConfig.verbose = config.verbose;
         rptConfig.dir = this.dir;
+        rptConfig.sourceStore = this.sourceStore;
         rptConfig.watermarks = config.reporting.watermarks();
         try {
             this.reports[fmt] = Report.create(fmt, rptConfig);


### PR DESCRIPTION
This currently does not work correctly with the HTML reporter, as we would need support two different features - resolving source maps and keeping the transpiled files in memory (the source code instrumented in the hook).

Hoping to open this for further discussion, as it would be amazing to get transpilers like Babel and TypeScript working with Istanbul without a pre-compilation step.

Related: https://github.com/blakeembrey/typescript-node/issues/2