### PR TITLE
Babel source map required option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ Changelog
 
 <table>
 <tr>
+<td>v0.3.20</td>
+<td>
+    <ul>
+        <li>Fix broken es6 `super` support, thanks @sterlinghw</li>
+        <li>Improve readability via better lineHeight, thanks @dhoko</li>
+        <li>Adding ability to set custom block name in teamcity report, thanks @aryelu</li>
+        <li>Replaced deprecated util.puts with console.log, thanks @arty-name
+    </ul>
+</td>
+</tr>
+<tr>
+<td>v0.3.19</td>
+<td>Fix instrumenter for multiple blank array positions, thanks @alexdunphy</td>
+</tr>
+<tr>
+<tr>
+<td>v0.3.18</td>
+<td>Upgrade esprima, get support for more ES6 features</td>
+</tr>
+<tr>
 <td>v0.3.17</td>
 <td>Upgrade esprima, get correct for-of support</td>
 </tr>

--- a/download-escodegen-browser.sh
+++ b/download-escodegen-browser.sh
@@ -6,6 +6,12 @@ OUT_FILE=${ESCG_DIR}/escodegen.browser.min.js
 if [ ! -f ${OUT_FILE} ]
 then
     set -v
-    curl -sSL -o ${ESCG_DIR}/escodegen.browser.min.js  https://raw.githubusercontent.com/estools/escodegen/${ESCG_VERSION}/escodegen.browser.min.js
+    rm -rf __escodegen_clone__
+    git clone --branch ${ESCG_VERSION} https://github.com/estools/escodegen.git __escodegen_clone__
+    cd __escodegen_clone__
+    npm i && npm run build-min
+    mv escodegen.browser.min.js ../${OUT_FILE}
+    cd -
+    rm -rf __escodegen_clone__
 fi
 

--- a/lib/assets/base.css
+++ b/lib/assets/base.css
@@ -39,7 +39,7 @@ pre {
     font-family: Consolas, Menlo, Monaco, monospace;
     margin: 0;
     padding: 0;
-    line-height: 14px;
+    line-height: 1.3;
     font-size: 14px;
     -moz-tab-size: 2;
     -o-tab-size:  2;

--- a/lib/command/instrument.js
+++ b/lib/command/instrument.js
@@ -223,7 +223,7 @@ Command.mix(InstrumentCommand, {
             mkdirp.sync(path.dirname(baselineFile));
             instrumenter = new BaselineCollector(instrumenter);
             process.on('exit', function () {
-                util.puts('Saving baseline coverage at: ' + baselineFile);
+                console.log('Saving baseline coverage at: ' + baselineFile);
                 fs.writeFileSync(baselineFile, JSON.stringify(instrumenter.getCoverage()), 'utf8');
             });
         }

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -122,7 +122,7 @@
         ReturnStatement: ['argument'],
         SequenceExpression: ['expressions'],
         SpreadElement: ['argument'],
-        SuperExpression: ['super'],
+        Super: [],
         SwitchStatement: ['discriminant', 'cases'],
         SwitchCase: ['test', 'consequent'],
         TaggedTemplateExpression: ['tag', 'quasi'],
@@ -240,6 +240,8 @@
                               pushAll(childArray, assignNode.prepend);
                               delete assignNode.prepend;
                           }
+                        } else {
+                            assignNode = undefined;
                         }
                         pushAll(childArray, assignNode);
                     }

--- a/lib/report/teamcity.js
+++ b/lib/report/teamcity.js
@@ -31,6 +31,7 @@ function TeamcityReport(opts) {
     opts = opts || {};
     this.dir = opts.dir || process.cwd();
     this.file = opts.file;
+    this.blockName = opts.blockName || this.getDefaultConfig().blockName;
 }
 
 TeamcityReport.TYPE = 'teamcity';
@@ -45,7 +46,7 @@ Report.mix(TeamcityReport, {
         return 'report with system messages that can be interpreted with TeamCity';
     },
     getDefaultConfig: function () {
-        return { file: null };
+        return { file: null , blockName: 'Code Coverage Summary'};
     },
     writeReport: function (collector /*, sync */) {
         var summaries = [],
@@ -61,7 +62,7 @@ Report.mix(TeamcityReport, {
         finalSummary = utils.mergeSummaryObjects.apply(null, summaries);
 
         lines.push('');
-        lines.push('##teamcity[blockOpened name=\'Code Coverage Summary\']');
+        lines.push('##teamcity[blockOpened name=\''+ this.blockName +'\']');
 
         //Statements Covered
         lines.push(lineForKey(finalSummary.statements.pct, 'CodeCoverageB'));
@@ -76,7 +77,7 @@ Report.mix(TeamcityReport, {
         lines.push(lineForKey(finalSummary.lines.total, 'CodeCoverageAbsLTotal'));
         lines.push(lineForKey(finalSummary.lines.pct, 'CodeCoverageL'));
 
-        lines.push('##teamcity[blockClosed name=\'Code Coverage Summary\']');
+        lines.push('##teamcity[blockClosed name=\''+ this.blockName +'\']');
 
         text = lines.join('\n');
         if (this.file) {

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -70,6 +70,9 @@ function rawMapFromUrl(url, base) {
     if (obj.sources && Array.isArray(obj.sources)) {
         obj.sources = obj.sources.map(function (s) {
             var file = firstFileOf(s,bases);
+            if(!file && s === 'unknown') {
+                throw new Error('Unable to find "sources" property on the source map');
+            }
             return file || s;
         });
     }

--- a/lib/store/fslookup.js
+++ b/lib/store/fslookup.js
@@ -37,7 +37,12 @@ Store.mix(LookupStore, {
         return [];
     },
     get: function (key) {
-        return fs.readFileSync(key, 'utf8');
+        try {
+            return fs.readFileSync(key, 'utf8');
+        }
+        catch (ex) {
+            throw new Error('Unable to read non-existent file [' + key + '] on a fslookup store');
+        }
     },
     hasKey: function (key) {
         var stats;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul",
-  "version": "0.3.17",
+  "version": "0.3.20",
   "description": "Yet another JS code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests. Supports all JS coverage use cases including unit tests, server side functional tests and browser tests. Built for scale",
   "keywords": [
     "coverage",
@@ -65,7 +65,12 @@
     "Ed S <ejsanders@gmail.com>",
     "Mordy Tikotzky <mordytk@gmail.com>",
     "Haoliang Gao @popomore <sakura9515@gmail.com>",
-    "Roderick Hsiao @roderickhsiao"
+    "Roderick Hsiao @roderickhsiao",
+    "Nikita Gusakov @nkt",
+    "Alex Dunphy @alexdunphy <alexanderdunphy@gmail.com>",
+    "Artemy Tregubenko @arty-name <me@arty.name>",
+    "Arye Lukashevski @aryelu",
+    "@sterlinghw"
   ],
   "scripts": {
     "pretest": "jshint index.js lib/ test/ && ./download-escodegen-browser.sh",
@@ -85,8 +90,8 @@
     "url": "git://github.com/gotwarlost/istanbul.git"
   },
   "dependencies": {
-    "esprima": "2.4.x",
-    "escodegen": "1.6.x",
+    "esprima": "2.5.x",
+    "escodegen": "1.7.x",
     "handlebars": "3.0.0",
     "mkdirp": "0.5.x",
     "nopt": "3.x",

--- a/test/cli/test-teamcity-report.js
+++ b/test/cli/test-teamcity-report.js
@@ -49,6 +49,24 @@ module.exports = {
         test.ok(reportLines.indexOf('CodeCoverageL') > 0);
 
         test.done();
+    },
+    "should allow to set custom Block name": function(test){
+    var file = path.resolve(OUTPUT_DIR, 'coverage.json'),
+        outFile = path.resolve(OUTPUT_DIR, 'teamcity-named.txt'),
+        reporter = new Reporter({ dir: OUTPUT_DIR, file: "teamcity-named.txt",  blockName: 'My Custom Block Name' }),
+        obj,
+        reportLines,
+        collector = new Collector();
+
+    obj = JSON.parse(fs.readFileSync(file, 'utf8'));
+    collector.add(obj);
+    reporter.writeReport(collector, true);
+    test.ok(existsSync(outFile));
+    reportLines = fs.readFileSync(outFile, 'utf8');
+
+    test.ok(reportLines.indexOf('##teamcity[blockOpened name=\'My Custom Block Name\']') > 0);
+    test.ok(reportLines.indexOf('##teamcity[blockClosed name=\'My Custom Block Name\']') > 0);
+    test.done();
     }
 };
 

--- a/test/es6.js
+++ b/test/es6.js
@@ -24,6 +24,10 @@ module.exports = {
         return tryThis('function *foo() { yield 1; }', 'yield');
     },
 
+    isSuperAvailable: function () {
+        return tryThis('class Test extends Object { constructor() { super(); } }\nnew Test();', 'super');
+    },
+
     isForOfAvailable: function () {
         return tryThis('function *foo() { yield 1; }\n' +
             'for (var k of foo()) {}', 'for-of');

--- a/test/instrumentation/test-es6-super.js
+++ b/test/instrumentation/test-es6-super.js
@@ -1,0 +1,70 @@
+/*jslint nomen: true */
+var helper = require('../helper'),
+    code,
+    verifier;
+
+if (require('../es6').isSuperAvailable()) {
+    module.exports = {
+        'should cover super in constructor': function (test) {
+            code = [
+                'class A {',
+                '   constructor(x) {',
+                '      this.x = x;',
+                '   }',
+                '   getX() {',
+                '      return "x";',
+                '   }',
+                '}',
+                'class B extends A {',
+                '   constructor(x) {',
+                '      super(x);',
+                '   }',
+                '   getX() {',
+                '      return this.x;',
+                '   }',
+                '}',
+                'output = (new B("super")).getX();'
+            ];
+            verifier = helper.verifier(__filename, code);
+            verifier.verify(test, ['super'], 'super', {
+                lines: { 3: 1, 6: 0, 11: 1, 14: 1, 17: 1 },
+                branches: {},
+                functions: { 1: 1, 2: 0, 3: 1, 4: 1 },
+                statements: { 1: 1, 2: 0, 3: 1, 4: 1, 5: 1 }
+            });
+            test.done();
+        },
+        'should cover super in method': function (test) {
+            code = [
+                'class A {',
+                '   constructor(x) {',
+                '      this.x = x;',
+                '   }',
+                '   getX() {',
+                '      return "x";',
+                '   }',
+                '}',
+                'class B extends A {',
+                '   constructor(x) {',
+                '      super(x);',
+                '   }',
+                '   getX() {',
+                '      return super.getX();',
+                '   }',
+                '}',
+                'output = (new B("super")).getX();'
+            ];
+            verifier = helper.verifier(__filename, code);
+            verifier.verify(test, ['super'], 'x', {
+                lines: { 3: 1, 6: 1, 11: 1, 14: 1, 17: 1 },
+                branches: {},
+                functions: { 1: 1, 2: 1, 3: 1, 4: 1 },
+                statements: { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1 }
+            });
+            test.done();
+        }
+    };
+}
+
+
+

--- a/test/instrumentation/test-expressions.js
+++ b/test/instrumentation/test-expressions.js
@@ -54,15 +54,15 @@ module.exports = {
     "with an array expression with empty positions": {
         setUp: function (cb) {
             code = [
-                'var x = [, , args[0], ];',
-                'output = x.indexOf(args[0]) === x.length - 1;'
+                'var x = [args[0], , args[1], ];',
+                'output = x.indexOf(args[1]) === x.length - 1 && x[0] !== x[1];'
             ];
             verifier = helper.verifier(__filename, code);
             cb();
         },
 
         "should not barf in any way": function (test) {
-            verifier.verify(test, [ 5 ], true, { lines: { 1: 1, 2: 1 }, branches: {}, functions: {}, statements: { '1': 1, '2': 1 } });
+            verifier.verify(test, [ 1, 5 ], true, { lines: { 1: 1, 2: 1 }, branches: { 1: [ 1, 1 ]}, functions: {}, statements: { '1': 1, '2': 1 } });
             test.done();
         }
     }


### PR DESCRIPTION
For Babel (6to5) to work with this branch the sourceFileName Babel option (http://babeljs.io/docs/usage/options/) must be set manually. Currently the error thrown is a bit mysterious and hard for the user to track what is wrong. I just treated the error with a friendlier message on 2 files. 

source-maps.js: entry point of the problem, added a message showing that "sources" property is missing
fslookup.js: end point of the problem. Generically try/catching file not found error