### PR TITLE
Babel source map required option

### DIFF
--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -70,6 +70,9 @@ function rawMapFromUrl(url, base) {
     if (obj.sources && Array.isArray(obj.sources)) {
         obj.sources = obj.sources.map(function (s) {
             var file = firstFileOf(s,bases);
+            if(!file && s === 'unknown') {
+                throw new Error('Unable to find "sources" property on the source map');
+            }
             return file || s;
         });
     }

--- a/lib/store/fslookup.js
+++ b/lib/store/fslookup.js
@@ -37,7 +37,12 @@ Store.mix(LookupStore, {
         return [];
     },
     get: function (key) {
-        return fs.readFileSync(key, 'utf8');
+        try {
+            return fs.readFileSync(key, 'utf8');
+        }
+        catch (ex) {
+            throw new Error('Unable to read non-existent file [' + key + '] on a fslookup store');
+        }
     },
     hasKey: function (key) {
         var stats;


### PR DESCRIPTION
For Babel (6to5) to work with this branch the sourceFileName Babel option (http://babeljs.io/docs/usage/options/) must be set manually. Currently the error thrown is a bit mysterious and hard for the user to track what is wrong. I just treated the error with a friendlier message on 2 files.

source-maps.js: entry point of the problem, added a message showing that "sources" property is missing
fslookup.js: end point of the problem. Generically try/catching file not found error