### PR TITLE
added protection around structuredText calls

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -197,7 +197,7 @@ function annotateStatements(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -228,7 +228,7 @@ function annotateFunctions(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -275,7 +275,7 @@ function annotateBranches(fileCoverage, structuredText) {
                 openSpan = lt + 'span class="branch-' + i + ' ' + (meta.skip ? 'cbranch-skip' : 'cbranch-no') + '"' + title('branch not covered') + gt;
                 closeSpan = lt + '/span' + gt;
 
-                if (count === 0) { //skip branches taken
+                if (count === 0 && structuredText[startLine]) { //skip branches taken
                     if (endLine !== startLine) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();


### PR DESCRIPTION
This should fix #429

It just checks for `structuredText[startLine]` before running the logic.

@gotwarlost thoughts?