### PR TITLE
update escodegen to its latest version, reenabling support for super()

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "abbrev": "1.0.x",
     "async": "1.x",
-    "escodegen": "1.6.x",
+    "escodegen": "1.7.x",
     "esprima": "2.5.x",
     "fileset": "0.2.x",
     "handlebars": "^4.0.1",


### PR DESCRIPTION
It looks like escodegen was accidentally changed to 1.6 in 48dc2de37c2b5cc318ee600e8adad8bccde8cd1a. This reverts the support for es6 super (#435)