### PR TITLE
Add tracker variable name in the coverage object

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -511,10 +511,13 @@
                 generated,
                 preamble,
                 lineCount,
+                tracker,
                 i;
             filename = filename || String(new Date().getTime()) + '.js';
+            tracker = generateTrackerVar(filename, this.omitTrackerSuffix);
             this.sourceMap = null;
             this.coverState = {
+                trackerVar: tracker,
                 path: filename,
                 s: {},
                 b: {},
@@ -524,7 +527,7 @@
                 branchMap: {}
             };
             this.currentState = {
-                trackerVar: generateTrackerVar(filename, this.omitTrackerSuffix),
+                trackerVar: tracker,
                 func: 0,
                 branch: 0,
                 variable: 0,


### PR DESCRIPTION
I have a special use case where I need to know the name of the tracking variable for a given coverage object.
To do this I can get the md5 of the [`path`](https://github.com/gotwarlost/istanbul/blob/4799c5823da130753cbe0f1c52423be6b9fb39dd/lib/instrumenter.js#L518) property like you do [here](https://github.com/gotwarlost/istanbul/blob/4799c5823da130753cbe0f1c52423be6b9fb39dd/lib/instrumenter.js#L43-L59) but to make it easier this patch exposes the variable name in a `trackerVar` property.