### PR TITLE
fix assetsDir path

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = {
     //undocumented
     TreeSummarizer: require('./lib/util/tree-summarizer'),
     //undocumented
-    assetsDir: path.resolve(__dirname, 'lib', 'vendor')
+    assetsDir: path.resolve(__dirname, 'lib', 'assets')
 };
 
 


### PR DESCRIPTION
old path was /lib/vendor, no longer exists, now it seems to be /lib/assets, needed in istanbul-middleware