### PR TITLE
Improve logging for phantom test launch failures

### DIFF
--- a/test/browser/test-browser-instrumentation.js
+++ b/test/browser/test-browser-instrumentation.js
@@ -52,9 +52,11 @@ module.exports = {
         }
 
         var server,
-            port = 9000;
+            port = 9000,
+            complete = false;
 
         var finalFn = function () {
+            complete = true;
             if (server) { server.close(); }
             if (!cp.exited) { cp.kill(); }
         };
@@ -84,6 +86,12 @@ module.exports = {
                 test.done();
             });
             runPhantom(phantom, path.resolve(__dirname, 'support', 'phantom-test.client.js'), port, filesToInstrument, function (err) {
+                if (complete) {
+                    return;
+                }
+
+                finalFn();
+
                 test.ok(false, err.message);
                 test.done();
             });

--- a/test/browser/test-browser-instrumentation.js
+++ b/test/browser/test-browser-instrumentation.js
@@ -10,7 +10,6 @@ var which = require('which'),
     ROOT = path.resolve(__dirname, '..', '..', 'lib'),
     common = require('../common'),
     filesToInstrument,
-    server,
     exited,
     cp;
 
@@ -51,12 +50,14 @@ module.exports = {
             test.done();
             return;
         }
+
+        var server,
+            port = 9000;
+
         var finalFn = function () {
             if (server) { server.close(); }
             if (!cp.exited) { cp.kill(); }
-        },
-            server,
-            port = 9000;
+        };
         try {
             console.log('Start server');
             server = require('./support/server').create(port, process.env.SELF_COVER ? instrumenter : null, ROOT);

--- a/test/cli/test-text-lcov-report.js
+++ b/test/cli/test-text-lcov-report.js
@@ -26,13 +26,13 @@ module.exports = {
     },
     "should print lcov.info to standard out": function (test) {
         var file = path.resolve(OUTPUT_DIR, 'coverage.json'),
+            output = '',
             reporter = new Reporter({
                 log: function (ln) {
                     output += ln;
                 }
             }),
-            collector = new Collector(),
-            output = '';
+            collector = new Collector();
 
         collector.add(JSON.parse(fs.readFileSync(file, 'utf8')));
         reporter.writeReport(collector, true);


### PR DESCRIPTION
When the phantom process crashes due to environmental issues, the tests would silently hang waiting for the server process to complete. This explicitly handles the error and terminates the test.

https://github.com/ariya/phantomjs/issues/12900 could contribute to this, among other errors.
