### PR TITLE
Prevent babel strict mode error due to strings

### DIFF
--- a/lib/report/common/defaults.js
+++ b/lib/report/common/defaults.js
@@ -26,9 +26,9 @@ module.exports = {
         /* istanbul ignore if: untestable in batch mode */
         if (supportsColor) {
             switch (clazz) {
-                case 'low' : str = '\033[91m' + str + '\033[0m'; break;
-                case 'medium': str = '\033[93m' + str + '\033[0m'; break;
-                case 'high': str = '\033[92m' + str + '\033[0m'; break;
+                case 'low' : str = '\x1B[91m' + str + '\x1B[0m'; break;
+                case 'medium': str = '\x1B[93m' + str + '\x1B[0m'; break;
+                case 'high': str = '\x1B[92m' + str + '\x1B[0m'; break;
             }
         }
         return str;


### PR DESCRIPTION
```
SyntaxError: istanbul/lib/report/html.js: lib/report/common/defaults.js: Octal literal in strict mode (29:36)
```

This can be reproduced if babel-core/register is loaded and excludes are not configured properly to ignore istanbul.