### PR TITLE
Add support for start and stop ignore hints

### DIFF
--- a/ignoring-code-for-coverage.md
+++ b/ignoring-code-for-coverage.md
@@ -23,6 +23,15 @@ the source code
   * A part of a logical expression in which case that part of the expression is ignored for branch coverage
 6. It is up to the caller to scope this as narrowly as possible. For example, if you have a source file that is wrapped
 in a function expression, adding `/* istanbul ignore next */` at the top of the file will ignore the whole file!
+7. Ranges of code may be skipped using `/* istanbul ignore start */` and `/* istanbul ignore end */`. When defined, these only ignore locations that they completely cover. Ex:
+
+  ```
+  /* istanbul ignore start */
+  if (foo || bar /* istanbul ignore end */) {
+  }
+  ```
+
+  Will only ignore the `foo || bar` portions of the code and the `if` will continue to be covered.
 
 ### How it works
 

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -566,7 +566,6 @@
             this.walker.startWalk(program);
             codegenOptions = this.opts.codeGenerationOptions || { format: { compact: !this.opts.noCompact }};
             codegenOptions.comment = this.opts.preserveComments;
-            //console.log(JSON.stringify(program, undefined, 2));
 
             generated = ESPGEN.generate(program, codegenOptions);
             preamble = this.getPreamble(originalCode || '', usingStrict);

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -787,16 +787,20 @@
         },
 
         maybeSkipNode: function (node, type) {
-            var alreadyIgnoring = !!this.currentState.ignoring,
-                hint = this.currentState.currentHint,
-                ignoreThis = !alreadyIgnoring && hint && hint.type === type;
-
-            if (ignoreThis) {
+            if (this.shouldSkip(node, type)) {
                 this.startIgnore();
                 node.postprocessor = this.endIgnore;
                 return true;
             }
             return false;
+        },
+        shouldSkip: function(node, type) {
+            var alreadyIgnoring = !!this.currentState.ignoring,
+                hint = this.currentState.currentHint;
+
+            return !alreadyIgnoring && hint &&
+                    (hint.type === type ||
+                        (hint.type === 'range' && hint.rangeEnd > node.range[1]));
         },
 
         coverMetaProperty: function(node /* , walker */) {
@@ -968,10 +972,8 @@
         },
 
         ifBranchInjector: function (node, walker) {
-            var alreadyIgnoring = !!this.currentState.ignoring,
-                hint = this.currentState.currentHint,
-                ignoreThen = !alreadyIgnoring && hint && hint.type === 'if',
-                ignoreElse = !alreadyIgnoring && hint && hint.type === 'else',
+            var ignoreThen = this.shouldSkip(node, 'if'),
+                ignoreElse = this.shouldSkip(node, 'else'),
                 line = node.loc.start.line,
                 col = node.loc.start.column,
                 makeLoc = function () { return  { line: line, column: col }; },
@@ -1029,8 +1031,7 @@
         maybeAddSkip: function (branchLocation) {
             return function (node) {
                 var alreadyIgnoring = !!this.currentState.ignoring,
-                    hint = this.currentState.currentHint,
-                    ignoreThis = !alreadyIgnoring && hint && hint.type === 'next';
+                    ignoreThis = this.shouldSkip(node, 'next');
                 if (ignoreThis) {
                     this.startIgnore();
                     node.postprocessor = this.endIgnore;

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -13,7 +13,7 @@
         crypto = isNode ? require('crypto') : null,
         LEADER_WRAP = '(function () { ',
         TRAILER_WRAP = '\n}());',
-        COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/,
+        COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next|start|end)(?=\W|$)/,
         astgen,
         preconditions,
         cond,
@@ -479,11 +479,12 @@
             }
             return this.instrumentASTSync(program, filename, code);
         },
-        filterHints: function (comments) {
+        filterHints: function (comments, program) {
             var ret = [],
                 i,
                 comment,
-                groups;
+                groups,
+                lastHint;
             if (!(comments && isArray(comments))) {
                 return ret;
             }
@@ -493,10 +494,28 @@
                 if (comment && comment.value && comment.range && isArray(comment.range)) {
                     groups = String(comment.value).match(COMMENT_RE);
                     if (groups) {
-                        ret.push({ type: groups[1], start: comment.range[0], end: comment.range[1] });
+                        if (lastHint && lastHint.type === 'start') {
+                            // If we have the end flag then finalize the range
+                            if (groups[1] === 'end') {
+                                lastHint.type = 'range';
+                                lastHint.rangeEnd = comment.range[1];
+                            }
+                            // Otherwise ignore the nested ignore
+                        } else {
+                            lastHint = { type: groups[1], start: comment.range[0], end: comment.range[1] };
+                            ret.push(lastHint);
+                        }
                     }
                 }
             }
+
+            // If there is a start without an end, then expand the range to cover the remainder of the file
+            if (lastHint && lastHint.type === 'start') {
+                lastHint.type = 'range';
+                var programEnd = program.body[program.body.length - 1];
+                lastHint.rangeEnd = programEnd.range[1] + 1;
+            }
+
             return ret;
         },
         extractCurrentHint: function (node) {
@@ -504,7 +523,25 @@
             var i = this.currentState.lastHintPosition + 1,
                 hints = this.currentState.hints,
                 nodeStart = node.range[0],
-                hint;
+                hint = this.currentState.currentHint;
+
+            // If we are still in a range, keep it running
+            if (hint) {
+                if (hint.type === 'range' && hint.rangeEnd > node.range[1]) {
+                    return;
+                }
+            }
+
+            // Check if we are part of a partial range overlap that didn't
+            // cover our parents completely
+            hint = hints[i - 1];
+            if (hint && hint.type === 'range' && hint.rangeEnd > node.range[1]) {
+                this.currentState.currentHint = hint;
+                this.currentState.lastHintPosition = i - 1;
+                return;
+            }
+
+            // Otherwise check for the next range
             this.currentState.currentHint = null;
             while (i < hints.length) {
                 hint = hints[i];
@@ -552,7 +589,7 @@
                 branch: 0,
                 variable: 0,
                 statement: 0,
-                hints: this.filterHints(program.comments),
+                hints: this.filterHints(program.comments, program),
                 currentHint: null,
                 lastHintPosition: -1,
                 ignoring: 0

--- a/test/instrumentation/test-range-hints.js
+++ b/test/instrumentation/test-range-hints.js
@@ -1,0 +1,363 @@
+/*jslint nomen: true */
+var helper = require('../helper'),
+    code,
+    verifier;
+
+module.exports = {
+    "without an end": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                'function foo(x) { return x; }',
+                'output = args[0];'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should not cover function call": function (test) {
+            verifier.verify(test, [ 10 ], 10, { lines: { 2: 1, 3: 1 }, branches: {}, functions: { 1: 0 }, statements: { 1: 1, 2: 0, 3: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.statementMap[1].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.fnMap[1].skip);
+            test.done();
+        }
+    },
+
+    "with multiple ranges": {
+        setUp: function (cb) {
+            code = [
+                'var _fs = 1;',
+                '/*istanbul ignore start*/',
+                'var _fs2 = 2;',
+                '/*istanbul ignore start*/',
+                'function _interopRequireDefault(obj) { return 1; }',
+                '/*istanbul ignore start*/',
+                'function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { return 1; } }',
+                '/*istanbul ignore end*/'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should expand to cover all of them": function (test) {
+            verifier.verify(test, [], undefined, {
+                lines: { 1: 1, 3: 1, 5: 1, 7: 1 },
+                branches: { 1: [ 0, 0 ] },
+                functions: { 1: 0, 2: 0 },
+                statements: { 1: 1, 2: 1, 3: 1, 4: 0, 5: 1, 6: 0, 7: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.statementMap[1].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.statementMap[3].skip);
+            test.equal(true, cov.statementMap[4].skip);
+            test.equal(true, cov.statementMap[5].skip);
+            test.equal(true, cov.statementMap[6].skip);
+            test.equal(true, cov.statementMap[7].skip);
+            test.done();
+        }
+    },
+
+    "with a function declaration": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                'function foo(x) { return x; }',
+                '/* istanbul ignore end */',
+                'output = args[0];'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should not cover function call": function (test) {
+            verifier.verify(test, [ 10 ], 10, { lines: { 2: 1, 4: 1 }, branches: {}, functions: { 1: 0 }, statements: { 1: 1, 2: 0, 3: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.statementMap[1].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.fnMap[1].skip);
+            test.done();
+        }
+    },
+    "with a function expression": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                '(function () { output = args[0]; })();',
+                '/* istanbul ignore end */'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should cover function call": function (test) {
+            verifier.verify(test, [ 10 ], 10, { lines: { 2: 1  }, branches: {}, functions: { 1: 1 }, statements: { 1: 1, 2: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.statementMap[1].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.fnMap[1].skip);
+            test.done();
+        }
+    },
+    "with a disabled switch statement": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                'switch (args[0]) {',
+                'case "1": output = 2; break;',
+                'default: output = 1;',
+                '}',
+                '/* istanbul ignore end */'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore all branches": function (test) {
+            verifier.verify(test, [ "1" ], 2, { lines: { 2: 1, 3: 1, 4: 1  }, branches: { 1: [ 1, 0 ]},
+                functions: {}, statements: { 1: 1, 2: 1, 3: 1, 4: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.statementMap[1].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.statementMap[3].skip);
+            test.equal(true, cov.statementMap[4].skip);
+            test.equal(true, cov.branchMap[1].locations[0].skip);
+            test.equal(true, cov.branchMap[1].locations[1].skip);
+            test.done();
+        }
+    },
+    "with a disabled case statement": {
+        setUp: function (cb) {
+            code = [
+                'switch (args[0]) {',
+                '/* istanbul ignore start */',
+                'case "1": output = 2; break;',
+                '/* istanbul ignore end */',
+                'default: output = 1;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore specific case": function (test) {
+            verifier.verify(test, [ "2" ], 1, { lines: { 1: 1, 3: 1, 5: 1  }, branches: { 1: [ 0, 1 ]},
+                functions: {}, statements: { 1: 1, 2: 0, 3: 0, 4: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.branchMap[1].locations[0].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.statementMap[3].skip);
+            test.done();
+        }
+    },
+    "with a disabled case statement across AST": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                'switch (args[0]) {',
+                'case "1": output = 2; break;',
+                '/* istanbul ignore end */',
+                'default: output = 1;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore specific case": function (test) {
+            verifier.verify(test, [ "2" ], 1, { lines: { 2: 1, 3: 1, 5: 1  }, branches: { 1: [ 0, 1 ]},
+                functions: {}, statements: { 1: 1, 2: 0, 3: 0, 4: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.branchMap[1].locations[0].skip);
+            test.equal(true, cov.statementMap[2].skip);
+            test.equal(true, cov.statementMap[3].skip);
+            test.done();
+        }
+    },
+
+    "with disabled conditional statement": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */',
+                'output = args[0] === 1 ? 1: 0;',
+                '/* istanbul ignore end */'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 2 ], 0, { lines: { 2: 1  }, branches: { 1: [ 0, 1 ]},
+                functions: {}, statements: { 1: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.branchMap[1].locations[0].skip);
+            test.equal(true, cov.branchMap[1].locations[1].skip);
+            test.equal(true, cov.statementMap[1].skip);
+            test.done();
+        }
+    },
+
+    "with disabled condition": {
+        setUp: function (cb) {
+            code = [
+                'output = args[0] === 1 ? /* istanbul ignore start */ 1 /* istanbul ignore end */ : 0;'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 2 ], 0, { lines: { 1: 1  }, branches: { 1: [ 0, 1 ]},
+                functions: {}, statements: { 1: 1 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.branchMap[1].locations[0].skip);
+            test.equal(undefined, cov.branchMap[1].locations[1].skip);
+            test.equal(undefined, cov.statementMap[1].skip);
+            test.done();
+        }
+    },
+
+    "with a simple logical expression": {
+        setUp: function (cb) {
+            code = [
+                'if (args[0] === 1  || /* istanbul ignore start */ args[0] === 2 /* istanbul ignore end */ ) {',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(true, cov.branchMap[2].locations[1].skip);
+            test.done();
+        }
+    },
+
+    "with a slightly complicated logical expression": {
+        setUp: function (cb) {
+            code = [
+                'if (args[0] === 1  || /* istanbul ignore start */ (args[0] === 2  || args[0] === 3) /* istanbul ignore end */) {',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.branchMap[2].locations[0].skip);
+            test.equal(true, cov.branchMap[2].locations[1].skip);
+            test.equal(true, cov.branchMap[2].locations[2].skip);
+            test.done();
+        }
+    },
+
+    "with a complicated logical expression involving implied operator precedence": {
+        setUp: function (cb) {
+            code = [
+                'if (args[0] === 1  || /* istanbul ignore start */ args[0] === 2 && args[1] === 2 /* istanbul ignore end */) {',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1, 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.branchMap[2].locations[0].skip);
+            test.equal(true, cov.branchMap[2].locations[1].skip);
+            test.equal(true, cov.branchMap[2].locations[2].skip);
+            test.done();
+        }
+    },
+    "with a complicated logical expression ignoring operator precedence": {
+        setUp: function (cb) {
+            code = [
+                'if (args[0] === 1  || /* istanbul ignore start */ args[0] === 2  /* istanbul ignore end */ && args[1] === 2) {',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1, 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.branchMap[2].locations[0].skip);
+            test.equal(true, cov.branchMap[2].locations[1].skip);
+            test.equal(undefined, cov.branchMap[2].locations[2].skip);
+            test.done();
+        }
+    },
+    "with partial starting AST overlap": {
+        setUp: function (cb) {
+            code = [
+                '/* istanbul ignore start */ if (args[0] === 1  || args[0] === 2  /* istanbul ignore end */ && args[1] === 2) {',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1, 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.branchMap[1].locations[0].skip);
+            test.equal(undefined, cov.branchMap[1].locations[1].skip);
+            test.equal(true, cov.branchMap[2].locations[0].skip);
+            test.equal(true, cov.branchMap[2].locations[1].skip);
+            test.equal(undefined, cov.branchMap[2].locations[2].skip);
+            test.done();
+        }
+    },
+    "with partial trailing AST overlap": {
+        setUp: function (cb) {
+            code = [
+                'if (args[0] === 1  || args[0] === 2  /* istanbul ignore start */ && args[1] === 2) {/* istanbul ignore end */',
+                '   output = args[0] + 10;',
+                '} else {',
+                '   output = 20;',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+
+        "should ignore conditions": function (test) {
+            verifier.verify(test, [ 1, 1 ], 11, { lines: { 1: 1, 2: 1, 4: 0 }, branches: { 1: [ 1, 0 ], 2: [ 1, 0, 0 ] },
+                functions: {}, statements: { 1: 1, 2: 1, 3: 0 } });
+            var cov = verifier.getFileCoverage();
+            test.equal(undefined, cov.branchMap[1].locations[0].skip);
+            test.equal(undefined, cov.branchMap[1].locations[1].skip);
+            test.equal(undefined, cov.branchMap[2].locations[0].skip);
+            test.equal(undefined, cov.branchMap[2].locations[1].skip);
+            test.equal(true, cov.branchMap[2].locations[2].skip);
+            test.done();
+        }
+    }
+};


### PR DESCRIPTION
Adds the ability to do `/* istanbul ignore start */` paired with `/* istanbul ignore end */` to ignore ranges of code rather than AST subtrees.

Functionally this allows for ignore flags at the same points within the tree and just provides syntax that doesn’t require annotating every AST node with the ignore flags.

When the flags partially cover a AST node, the AST is considered NOT skip, but any children that are fully covered will be skipped. Tests for both of these cases are included.

Fixes #413
