### PR TITLE
Update to latest Esprima 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "abbrev": "1.0.x",
     "async": "1.x",
     "escodegen": "1.7.x",
-    "esprima": "2.5.x",
+    "esprima": "2.7.x",
     "fileset": "0.2.x",
     "handlebars": "^4.0.1",
     "js-yaml": "3.x",


### PR DESCRIPTION
There were numerous parsing improvements and fixes (see the [ChangeLog](https://github.com/jquery/esprima/blob/master/ChangeLog)) which will benefit Istanbul.

This shoud be a drop-in compatible. During the development of 2.7, Istanbul was repeatedly tested from every commit of Esprima (the so-called "downstream test").