### PR TITLE
Support custom registered extensions

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -156,7 +156,11 @@ function run(args, commandName, enableHooks, callback) {
                 if (err) { return callback(err); }
 
                 var coverageVar = '$$cov_' + new Date().getTime() + '$$',
-                    instrumenter = new Instrumenter({ coverageVariable: coverageVar , preserveComments: preserveComments}),
+                    instrumenter = new Instrumenter({
+                        coverageVariable: coverageVar,
+                        preserveComments: preserveComments,
+                        embedSource: config.instrumentation.embedSource()
+                    }),
                     transformer = instrumenter.instrumentSync.bind(instrumenter),
                     hookOpts = { verbose: verbose, extensions: config.instrumentation.extensions() },
                     postRequireHook = config.hooks.postRequireHook(),

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -32,7 +32,6 @@
  * @module main
  */
 var path = require('path'),
-    fs = require('fs'),
     Module = require('module'),
     vm = require('vm'),
     originalLoaders = {},
@@ -102,12 +101,15 @@ function hookRequire(matcher, transformer, options) {
             originalLoaders[ext] = Module._extensions[ext] || Module._extensions['.js'];
         } 
         Module._extensions[ext] = function (module, filename) {
-            var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
-            if (ret.changed) {
-                module._compile(ret.code, filename);
-            } else {
-                originalLoaders[ext](module, filename);
-            }
+            var compiler = module._compile;
+
+            module._compile = function(code, filename) {
+              var ret = fn(code, filename);
+              compiler.call(module, ret.code, filename);
+            };
+
+            originalLoaders[ext](module, filename);
+
             if (postLoadHook) {
                 postLoadHook(filename);
             }


### PR DESCRIPTION
This pull request adds two features:

- Override `module._compile` before we call the original extension-handler such that we can instrument custom registered extensions (like CoffeeScript and Babel).
- Respect `embed-source` in `istanbul cover`

After this patch I can do the following:

```
$ cat .istanbul.yml
instrumentation:
  embed-source: true
$ cat .babelrc
{
  "presets": ["es2015"]
}
$ cat foo.js
class Foo {
};
$ node -r babel-register ./lib/cli.js cover foo.js
=============================================================================
Writing coverage object [/Users/magnus/Programming/sources/istanbul/coverage/coverage.json]
Writing coverage reports at [/Users/magnus/Programming/sources/istanbul/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 40% ( 2/5 )
Branches     : 0% ( 0/2 )
Functions    : 0% ( 0/2 )
Lines        : 66.67% ( 2/3 )
================================================================================
```

Note that it will instrument the processed JavaScript code.