### PR TITLE
MetaProperty support

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -109,6 +109,7 @@
         Literal: [],
         LabeledStatement: ['label', 'body'],
         LogicalExpression: ['left', 'right'],
+        MetaProperty: ['meta', 'property'],
         MemberExpression: ['object', 'property'],
         MethodDefinition: ['key', 'value'],
         ModuleSpecifier: [],
@@ -221,6 +222,10 @@
             if (walkerFn) {
                 ret = walker.apply(node, walkerFn);
             }
+        }
+
+        if (node.skipSelf) {
+            return;
         }
 
         for (i = 0; i < children.length; i += 1) {
@@ -418,7 +423,8 @@
             LabeledStatement: this.coverStatement,
             ConditionalExpression: this.conditionalBranchInjector,
             LogicalExpression: this.logicalExpressionBranchInjector,
-            ObjectExpression: this.maybeAddType
+            ObjectExpression: this.maybeAddType,
+            MetaProperty: this.coverMetaProperty,
         }, this.extractCurrentHint, this, this.opts.walkDebug);
 
         //unit testing purposes only
@@ -787,6 +793,10 @@
             return false;
         },
 
+        coverMetaProperty: function(node /* , walker */) {
+           node.skipSelf = true;
+        },
+
         coverStatement: function (node, walker) {
             var sName,
                 incrStatementCount,
@@ -1038,7 +1048,7 @@
                     child.type = SYNTAX.Property.name;
                 }
             }
-        }
+        },
     };
 
     if (isNode) {

--- a/test/instrumentation/test-statement.js
+++ b/test/instrumentation/test-statement.js
@@ -24,6 +24,27 @@ module.exports = {
             test.done();
         }
     },
+    "with a metaproperty": {
+        setUp: function (cb) {
+            code = [
+                'class FooClass {',
+                '   constructor() {',
+                '       if (new.target === FooClass) {',
+                '           throw new Error(\'Cannot instanciate directly.\');',
+                '       }',
+                '   }',
+                '}'
+            ];
+            verifier = helper.verifier(__filename, code);
+            cb();
+        },
+        "should be able to parse": function (test) {
+            // Do we need to test coverage here really? We're just checking
+            // that a new type of statement is parsable, the if-else logic
+            // is already covered in statement-if.
+            test.done();
+        }
+    },
     "with no filename": {
         setUp: function (cb) {
             code = [


### PR DESCRIPTION
Hello,

I've just made a contribution to ESCodeGen to support MetaProperties, and this is the change to add the support for this into Istanbul.

The upstream dependency is: https://github.com/estools/escodegen/pull/275

This will have no immediate effect until they release the upstream version. The change implements a 'skipSelf' option on the node, allowing an early bailout from the child node walker since unlike other property expressions, both 'meta' and 'property' on the MetaProperty node are just strings, and cannot have additional sub-properties added due to strings being read only.

My question is: Is this the right way to go about this? It's very hard to run the NPM test suite on Windows due to the shell scripting and Unix-paths used in places, but in some local testing this appears to work fine.