### PR TITLE
Handle ExportNamedDeclarations

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -815,7 +815,7 @@
                 // We let `coverExport` handle ExportNamedDeclarations.
                 parent = walker.parent();
                 if (parent && parent.node.type === SYNTAX.ExportNamedDeclaration.name) {
-                  return;
+                    return;
                 }
 
                 sName = this.statementName(node.loc);

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -397,6 +397,7 @@
         this.walker = new Walker({
             ArrowFunctionExpression: [ this.arrowBlockConverter ],
             ExpressionStatement: this.coverStatement,
+            ExportNamedDeclaration: this.coverExport,
             BreakStatement: this.coverStatement,
             ContinueStatement: this.coverStatement,
             DebuggerStatement: this.coverStatement,
@@ -791,7 +792,6 @@
             var sName,
                 incrStatementCount,
                 parent,
-                insertionTarget,
                 grandParent;
 
             this.maybeSkipNode(node, 'next');
@@ -820,19 +820,34 @@
                     )
                 );
 
-                // The insertion target for `incrStatementCount` is usually the current node.
-                insertionTarget = node;
-
-                // However, to handle ExportNamedDeclarations, like `export var ...`
-                // We must insert the statement before our parent node,
-                // if it is such an export statement.
+                // We let `coverExport` handle ExportNamedDeclarations.
                 parent = walker.parent();
                 if (parent && parent.node.type === SYNTAX.ExportNamedDeclaration.name) {
-                  insertionTarget = parent;
+                  return;
                 }
 
-                this.splice(incrStatementCount, insertionTarget, walker);
+                this.splice(incrStatementCount, node, walker);
             }
+        },
+
+        coverExport: function (node, walker) {
+          var sName, incrStatementCount;
+
+          if ( !node.declaration ) return;
+
+          this.maybeSkipNode(node, 'next');
+
+          sName = this.statementName(node.loc);
+          incrStatementCount = astgen.statement(
+              astgen.postIncrement(
+                  astgen.subscript(
+                      astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
+                      astgen.stringLiteral(sName)
+                  )
+              )
+          );
+
+          this.splice(incrStatementCount, node, walker);
         },
 
         splice: function (statements, node, walker) {

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -790,6 +790,8 @@
         coverStatement: function (node, walker) {
             var sName,
                 incrStatementCount,
+                parent,
+                insertionTarget,
                 grandParent;
 
             this.maybeSkipNode(node, 'next');
@@ -817,7 +819,19 @@
                         )
                     )
                 );
-                this.splice(incrStatementCount, node, walker);
+
+                // The insertion target for `incrStatementCount` is usually the current node.
+                insertionTarget = node;
+
+                // However, to handle ExportNamedDeclarations, like `export var ...`
+                // We must insert the statement before our parent node,
+                // if it is such an export statement.
+                parent = walker.parent();
+                if (parent && parent.node.type === SYNTAX.ExportNamedDeclaration.name) {
+                  insertionTarget = parent;
+                }
+
+                this.splice(incrStatementCount, insertionTarget, walker);
             }
         },
 
@@ -1048,4 +1062,3 @@
     }
 
 }(typeof module !== 'undefined' && typeof module.exports !== 'undefined' && typeof exports !== 'undefined'));
-

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -807,10 +807,19 @@
                     }
                 }
             }
+
             if (node.type === SYNTAX.FunctionDeclaration.name) {
-                sName = this.statementName(node.loc, 1);
+                // Called for the side-effect of setting the function's statement count to 1.
+                this.statementName(node.loc, 1);
             } else {
+                // We let `coverExport` handle ExportNamedDeclarations.
+                parent = walker.parent();
+                if (parent && parent.node.type === SYNTAX.ExportNamedDeclaration.name) {
+                  return;
+                }
+
                 sName = this.statementName(node.loc);
+
                 incrStatementCount = astgen.statement(
                     astgen.postIncrement(
                         astgen.subscript(
@@ -820,34 +829,28 @@
                     )
                 );
 
-                // We let `coverExport` handle ExportNamedDeclarations.
-                parent = walker.parent();
-                if (parent && parent.node.type === SYNTAX.ExportNamedDeclaration.name) {
-                  return;
-                }
-
                 this.splice(incrStatementCount, node, walker);
             }
         },
 
         coverExport: function (node, walker) {
-          var sName, incrStatementCount;
+            var sName, incrStatementCount;
 
-          if ( !node.declaration ) return;
+            if ( !node.declaration || !node.declaration.declarations ) { return; }
 
-          this.maybeSkipNode(node, 'next');
+            this.maybeSkipNode(node, 'next');
 
-          sName = this.statementName(node.loc);
-          incrStatementCount = astgen.statement(
-              astgen.postIncrement(
-                  astgen.subscript(
-                      astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
-                      astgen.stringLiteral(sName)
-                  )
-              )
-          );
+            sName = this.statementName(node.declaration.loc);
+            incrStatementCount = astgen.statement(
+                astgen.postIncrement(
+                    astgen.subscript(
+                        astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
+                        astgen.stringLiteral(sName)
+                    )
+                )
+            );
 
-          this.splice(incrStatementCount, node, walker);
+            this.splice(incrStatementCount, node, walker);
         },
 
         splice: function (statements, node, walker) {

--- a/test/es6.js
+++ b/test/es6.js
@@ -1,16 +1,25 @@
 var esprima = require('esprima');
 
 function tryThis(str, feature) {
-    try {
-        /*jshint evil: true */
-        eval(str);
-    } catch (ex) {
-        console.error('ES6 feature [' + feature + '] is not available in this environment');
-        return false;
+    // We can test instrumentation of exports even if the environment doesn't support them. 
+    if (feature !== 'export') {
+        try {
+            /*jshint evil: true */
+            eval(str);
+        } catch (ex) {
+            console.error('ES6 feature [' + feature + '] is not available in this environment');
+            return false;
+        }
     }
 
+   // esprima parses sources with sourceType 'script' per default.
+   // The only way to enable `import`/`export` is to parse as sourceType 'module'.
    try {
-       esprima.parse(str);
+       try {
+           esprima.parse(str);
+       } catch (ex) {
+           esprima.parse(str, { sourceType: 'module' });
+       }
    } catch (ex) {
        console.error('ES6 feature [' + feature + '] is not yet supported by esprima mainline');
        return false;

--- a/test/es6.js
+++ b/test/es6.js
@@ -1,15 +1,12 @@
 var esprima = require('esprima');
 
 function tryThis(str, feature) {
-    // We can test instrumentation of exports even if the environment doesn't support them. 
-    if (feature !== 'export') {
-        try {
-            /*jshint evil: true */
-            eval(str);
-        } catch (ex) {
-            console.error('ES6 feature [' + feature + '] is not available in this environment');
-            return false;
-        }
+    try {
+        /*jshint evil: true */
+        eval(str);
+    } catch (ex) {
+        console.error('ES6 feature [' + feature + '] is not available in this environment');
+        return false;
     }
 
    // esprima parses sources with sourceType 'script' per default.
@@ -51,6 +48,7 @@ module.exports = {
     },
 
     isExportAvailable: function () {
-        return tryThis('export default function foo() {}', 'export');
+        // We can test instrumentation of exports even if the environment doesn't support them.
+        return true;
     }
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -104,6 +104,11 @@ function setup(file, codeArray, opts) {
                 }
                 return;
             }
+
+            // `export`/`import` cannot be wrapped inside a function.
+            // For our purposes, simply remove the `export` from export declarations.
+            generated = generated.replace(/export (var|function|let|const)/g, '$1');
+
             var wrappedCode = '(function (args) { var output;\n' + generated + '\nreturn output;\n})',
                 fn;
             global[coverageVariable] = undefined;

--- a/test/helper.js
+++ b/test/helper.js
@@ -107,7 +107,9 @@ function setup(file, codeArray, opts) {
 
             // `export`/`import` cannot be wrapped inside a function.
             // For our purposes, simply remove the `export` from export declarations.
-            generated = generated.replace(/export (var|function|let|const)/g, '$1');
+            if ( opts.esModules ) {
+                generated = generated.replace(/export (var|function|let|const)/g, '$1');
+            }
 
             var wrappedCode = '(function (args) { var output;\n' + generated + '\nreturn output;\n})',
                 fn;

--- a/test/instrumentation/test-es6-export.js
+++ b/test/instrumentation/test-es6-export.js
@@ -21,6 +21,24 @@ if (require('../es6').isExportAvailable()) {
                 statements: {'1': 1, '2': 1, '3': 1}
             });
             test.done();
+        },
+
+        'should cover export declarations': function (test) {
+          code = [
+              'export var a = 2, b = 3;',
+              'output = a + b'
+          ];
+          verifier = helper.verifier(__filename, code, {
+              esModules: true,
+              noAutoWrap: true
+          });
+          verifier.verify(test, [], 5, {
+              lines: {'1':1, '2': 1},
+              branches: {},
+              functions: {},
+              statements: {'1': 1, '2': 1}
+          });
+          test.done();
         }
     };
 }

--- a/test/instrumentation/test-es6-export.js
+++ b/test/instrumentation/test-es6-export.js
@@ -24,21 +24,21 @@ if (require('../es6').isExportAvailable()) {
         },
 
         'should cover export declarations': function (test) {
-          code = [
-              'export var a = 2, b = 3;',
-              'output = a + b'
-          ];
-          verifier = helper.verifier(__filename, code, {
-              esModules: true,
-              noAutoWrap: true
-          });
-          verifier.verify(test, [], 5, {
-              lines: {'1':1, '2': 1},
-              branches: {},
-              functions: {},
-              statements: {'1': 1, '2': 1}
-          });
-          test.done();
+            code = [
+                'export var a = 2, b = 3;',
+                'output = a + b'
+            ];
+            verifier = helper.verifier(__filename, code, {
+                esModules: true,
+                noAutoWrap: true
+            });
+            verifier.verify(test, [], 5, {
+                lines: {'1':1, '2': 1},
+                branches: {},
+                functions: {},
+                statements: {'1': 1, '2': 1}
+            });
+            test.done();
         }
     };
 }


### PR DESCRIPTION
Istanbul currently doesn't handle `export var ...`, and throws:
```
/Users/oskar/github/istanbul/lib/instrumenter.js:252
                        throw new Error('Internal error: attempt to prepend statements in disallowed (non-array) context');
                        ^

Error: Internal error: attempt to prepend statements in disallowed (non-array) context
    at Object.defaultWalker (/Users/oskar/github/istanbul/lib/instrumenter.js:252:31)
    at Object.Walker.apply (/Users/oskar/github/istanbul/lib/instrumenter.js:297:26)
    at Object.defaultWalker (/Users/oskar/github/istanbul/lib/instrumenter.js:237:47)
    at Object.Walker.apply (/Users/oskar/github/istanbul/lib/instrumenter.js:297:26)
    at Object.Walker.startWalk (/Users/oskar/github/istanbul/lib/instrumenter.js:281:18)
    at Object.Instrumenter.instrumentASTSync (/Users/oskar/github/istanbul/lib/instrumenter.js:554:25)
    at Object.Instrumenter.instrumentSync (/Users/oskar/github/istanbul/lib/instrumenter.js:468:25)
    at Object.<anonymous> (/Users/oskar/github/istanbul/exec.js:7:27)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
```

This PR attempts to rectify this.