### PR TITLE
fix remain argv

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -101,7 +101,7 @@ function run(args, commandName, enableHooks, callback) {
     }
 
     cmd = cmdAndArgs.shift();
-    cmdArgs = cmdAndArgs;
+    cmdArgs = args.slice(args.indexOf(cmd));
 
     if (!existsSync(cmd)) {
         try {


### PR DESCRIPTION
the original process.argv is
```
 [ '/usr/local/bin/node',
  '/Users/taojie/work/node_source/midway-core/node_modules/.bin/istanbul',
  'cover',
  '--report',
  'none',
  '--print',
  'none',
  '--include-pid',
  '/Users/taojie/work/node_source/midway-core/lib/process/agent_worker.js',
  '--baseDir',
  '/Users/taojie/work/node_source/midway-core/test/fixtures/apps/logrotater-app-size' ]
```
and the remain argv is
```
[ '/Users/taojie/work/node_source/midway-core/lib/process/agent_worker.js',
  '/Users/taojie/work/node_source/midway-core/test/fixtures/apps/logrotater-app-size' ]
```

but it should be
[ '--baseDir',
  '/Users/taojie/work/node_source/midway-core/test/fixtures/apps/logrotater-app-size' ]

this pr  will fix this!