### PR TITLE
Avoid throwing error in html reporter

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -285,6 +285,9 @@ function annotateBranches(fileCoverage, structuredText) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();
                     }
+                    if (!structuredText[startLine]) {
+                        return;
+                    }
                     text = structuredText[startLine].text;
                     if (branchMeta[branchName].type === 'if') { // and 'if' is a special case since the else branch might not be visible, being non-existent
                         text.insertAt(startCol, lt + 'span class="' + (meta.skip ? 'skip-if-branch' : 'missing-if-branch') + '"' +


### PR DESCRIPTION
I'm not sure why this is happening, and perhaps someone else knows of a better fix.  This one feels kludgey, like a condition that should never happen, and thus is indicating an error elsewhere which should be fixed in a different way.

Nevertheless, this makes my html reporter stop throwing an error on my machine, and doesn't appear to have any other negative side effects.