### PR TITLE
Create new instance of Handlebars.

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -4,7 +4,7 @@
  */
 
 /*jshint maxlen: 300 */
-var handlebars = require('handlebars'),
+var handlebars = require('handlebars').create(),
     defaults = require('./common/defaults'),
     path = require('path'),
     fs = require('fs'),
@@ -496,7 +496,7 @@ Report.mix(HtmlReport, {
         return {
             fromParent: function (node) {
                 var relativeName = cleanPath(node.relativeName);
-                
+
                 return node.kind === 'dir' ? relativeName + 'index.html' : relativeName + '.html';
             },
             ancestorHref: function (node, num) {


### PR DESCRIPTION
This PR creates a new instance of Handlebars when creating the html report. This is so helpers used in the instrumented application don't leak into the report.