### PR TITLE
Fixes #539. Adds support for 'use strict' statement within arrow functions

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -718,13 +718,27 @@
         },
 
         arrowBlockConverter: function (node) {
-            var retStatement;
+            var retStatement, popped;
             if (node.expression) { // turn expression nodes into a block with a return statement
                 retStatement = astgen.returnStatement(node.body);
                 // ensure the generated return statement is covered
                 retStatement.loc = node.body.loc;
                 node.body = this.convertToBlock(retStatement);
                 node.expression = false;
+            }
+            if (node.body &&node.body.length > 0 && this.isUseStrictExpression(node.body[0])) {
+                popped = node.body.shift();
+                node.body.unshift(
+                    astgen.statement(
+                        astgen.postIncrement(
+                            astgen.subscript(
+                                astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
+                                astgen.stringLiteral(this.statementName(node.body.loc))
+                            )
+                        )
+                    )
+                );
+                node.body.unshift(popped);
             }
         },
 
@@ -809,7 +823,8 @@
                 /* istanbul ignore else: difficult to test */
                 if (grandParent) {
                     if ((grandParent.node.type === SYNTAX.FunctionExpression.name ||
-                        grandParent.node.type === SYNTAX.FunctionDeclaration.name)  &&
+                        grandParent.node.type === SYNTAX.FunctionDeclaration.name ||
+                        grandParent.node.type === SYNTAX.ArrowFunctionExpression.name)  &&
                         walker.parent().node.body[0] === node) {
                         return;
                     }

--- a/test/instrumentation/test-es6-arrow-fn.js
+++ b/test/instrumentation/test-es6-arrow-fn.js
@@ -45,6 +45,21 @@ if (require('../es6').isArrowFnAvailable()) {
                 verifier.verify(test, [], [], { lines: { '1': 1, '2': 1 }, branches: {}, functions: {}, statements: { '1': 1, '2': 1, '3': 0} });
                 test.done();
             }
+        },
+        "with a block arrow expression that uses strict": {
+            setUp: function (cb) {
+                code = [
+                    'var input = args',
+                    'output = input.map(x => { "use strict"; return x * x; })'
+                ];
+                verifier = helper.verifier(__filename, code);
+                cb();
+            },
+            
+            "should cover one statement less": function (test) {
+                verifier.verify(test, [], [], { lines: { '1': 1, '2': 1 }, branches: {}, functions: {}, statements: { '1': 1, '2': 1, '3': 0} });
+                test.done();
+            }
         }
     };
 }


### PR DESCRIPTION
I'm not totally sure about how to test this, but I've tried to be consistent with the existing tests for arrow functions and for strict mode.