### PR TITLE
Source root fix

### DIFF
--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -72,6 +72,9 @@ function rawMapFromUrl(url, base) {
             var file = firstFileOf(s,bases);
             return file || s;
         });
+        // as we resoved the full path to source files, clear the sourceRoot.
+        // If someone tries to add to the source file, it will not do any harm anymore. 
+        obj.sourceRoot = '';
     }
     return obj;
 }

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -72,8 +72,6 @@ function rawMapFromUrl(url, base) {
             var file = firstFileOf(s,bases);
             return file || s;
         });
-        // as we resoved the full path to source files, clear the sourceRoot.
-        // If someone tries to add to the source file, it will not do any harm anymore. 
         obj.sourceRoot = '';
     }
     return obj;


### PR DESCRIPTION
The obj.sources is changed and now contains full absolute file names. Other libraries ('source-map') expect it to be relative to obj.sourceRoot and may behave incorrectly (and so they did). If the sources  are changed, so the sourceRoot must do accordingly.