### PR TITLE
Fix report colors in terminal

### DIFF
--- a/lib/report/common/defaults.js
+++ b/lib/report/common/defaults.js
@@ -26,9 +26,9 @@ module.exports = {
         /* istanbul ignore if: untestable in batch mode */
         if (supportsColor) {
             switch (clazz) {
-                case 'low' : str = '\x1B[91m' + str + '\x1B[0m'; break;
-                case 'medium': str = '\x1B[93m' + str + '\x1B[0m'; break;
-                case 'high': str = '\x1B[92m' + str + '\x1B[0m'; break;
+                case 'low' : str = '\u001B[91m' + str + '\u001B[0m'; break;
+                case 'medium': str = '\u001B[93m' + str + '\u001B[0m'; break;
+                case 'high': str = '\u001B[92m' + str + '\u001B[0m'; break;
             }
         }
         return str;


### PR DESCRIPTION
Uses other encoding type of setting colors.