### PR TITLE
correct ansi colors for 16 colors environments

### DIFF
--- a/lib/report/common/defaults.js
+++ b/lib/report/common/defaults.js
@@ -24,12 +24,13 @@ module.exports = {
 
     colorize: function (str, clazz) {
         /* istanbul ignore if: untestable in batch mode */
-        if (supportsColor) {
-            var colors = {
-                low: '31;1',
-                medium: '33;1',
-                high: '32;1'
-            };
+        var colors = {
+            low: '31;1',
+            medium: '33;1',
+            high: '32;1'
+        };
+        
+        if (supportsColor && colors[clazz]) {
             return '\u001b[' + colors[clazz] + 'm' + str + '\u001b[0m';
         }
         return str;

--- a/lib/report/common/defaults.js
+++ b/lib/report/common/defaults.js
@@ -25,11 +25,12 @@ module.exports = {
     colorize: function (str, clazz) {
         /* istanbul ignore if: untestable in batch mode */
         if (supportsColor) {
-            switch (clazz) {
-                case 'low' : str = '\x1B[91m' + str + '\x1B[0m'; break;
-                case 'medium': str = '\x1B[93m' + str + '\x1B[0m'; break;
-                case 'high': str = '\x1B[92m' + str + '\x1B[0m'; break;
-            }
+            var colors = {
+                low: '31;1',
+                medium: '33;1',
+                high: '32;1'
+            };
+            return '\u001b[' + colors[clazz] + 'm' + str + '\u001b[0m';
         }
         return str;
     },


### PR DESCRIPTION
Colors were used from the non-standard 90-97 ansi range. Travis, and some other terminals, does not support these and so show white text. With this change the colors are visible again.

Proof at the travis logs of this PR https://travis-ci.org/gotwarlost/istanbul/jobs/117557241#L3662

