### PR TITLE
CHORE - Remove Trailing Spaces

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -98,9 +98,9 @@ function hookRequire(matcher, transformer, options) {
     extensions = options.extensions || ['.js'];
 
     extensions.forEach(function(ext){
-        if (!(ext in originalLoaders)) { 
+        if (!(ext in originalLoaders)) {
             originalLoaders[ext] = Module._extensions[ext] || Module._extensions['.js'];
-        } 
+        }
         Module._extensions[ext] = function (module, filename) {
             var ret = fn(fs.readFileSync(filename, 'utf8'), filename);
             if (ret.changed) {

--- a/misc/ast/do-statement.js
+++ b/misc/ast/do-statement.js
@@ -1,5 +1,5 @@
 var i = 5;
-do 
+do
 	i--;
  while (i > 0);
 

--- a/misc/ast/label.js
+++ b/misc/ast/label.js
@@ -1,7 +1,7 @@
 var items= [],itemsPassed = 0;
 var i, j;
 
-function foo() 
+function foo()
 {
 top:
     for (i = 0; i < items.length; i++){

--- a/test/cli/test-html-report.js
+++ b/test/cli/test-html-report.js
@@ -237,7 +237,7 @@ module.exports = {
             },
             relativeName: 'generate-names-mangled.js'
         };
-        
+
         result = reporter.standardLinkMapper().ancestorHref(node, 2);
 
         test.ok(result === '../../');
@@ -262,7 +262,7 @@ module.exports = {
             },
             relativeName: 'generate-names-mangled.js'
         };
-        
+
         result = reporter.standardLinkMapper().ancestorHref(node, 2);
 
         test.ok(result === '../../');

--- a/test/cli/test-json-summary-report.js
+++ b/test/cli/test-json-summary-report.js
@@ -45,7 +45,7 @@ module.exports = {
         });
         finalSummary = objectUtils.mergeSummaryObjects.apply(null, summaries);
         obj.total = finalSummary;
-        
+
         test.ok(existsSync(jsonFile));
         reportObj = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
         test.deepEqual(Object.keys(obj).sort(), Object.keys(reportObj).sort());


### PR DESCRIPTION
Remove Trailing Spaces:

Why:
Saves space
Reduces silly conflicts