### PR TITLE
speedup of report generation for large projects

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -432,7 +432,8 @@
         mergeFileCoverage: mergeFileCoverage,
         mergeSummaryObjects: mergeSummaryObjects,
         toYUICoverage: toYUICoverage,
-        incrementIgnoredTotals: incrementIgnoredTotals
+        incrementIgnoredTotals: incrementIgnoredTotals,
+        deepClone: deepClone
     };
 
     /* istanbul ignore else: windows */

--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -37,6 +37,26 @@
  * @static
  */
 (function (isNode) {
+    /// Simple, unfancy deep cloning for Objects without circular references.
+    function deepClone(object) {
+        if (typeof object !== 'object') {
+            return object;
+        }
+
+        if (Array.isArray(object)) {
+            return object.map(deepClone);
+        }
+
+        var keys = Object.keys(object);
+        var cloned = {};
+
+        for (var i = 0; i < keys.length; i += 1) {
+            cloned[keys[i]] = deepClone(object[keys[i]]);
+        }
+
+        return cloned;
+    }
+
     /**
      * adds line coverage information to a file coverage object, reverse-engineering
      * it from statement coverage. The object passed in is updated in place.
@@ -230,8 +250,7 @@
      *      the input objects are not changed in any way.
      */
     function mergeFileCoverage(first, second) {
-        var ret = JSON.parse(JSON.stringify(first)),
-            i;
+        var ret = deepClone(first), i;
 
         delete ret.l; //remove derived info
 

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -22,7 +22,7 @@ var util = require('util'),
  */
 function MemoryStore() {
     Store.call(this);
-    this.map = {};
+    this.map = Object.create(null);
 }
 
 MemoryStore.TYPE = 'memory';
@@ -41,7 +41,7 @@ Store.mix(MemoryStore, {
     },
 
     hasKey: function (key) {
-        return this.map.hasOwnProperty(key);
+        return Object.prototype.hasOwnProperty.call(this.map, key);
     },
 
     keys: function () {
@@ -49,7 +49,7 @@ Store.mix(MemoryStore, {
     },
 
     dispose: function () {
-        this.map = {};
+        this.map = Object.create(null);
     }
 });
 

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -4,7 +4,8 @@
  */
 
 var util = require('util'),
-    Store = require('./index');
+    Store = require('./index'),
+    deepClone = require('../object-utils').deepClone;
 
 /**
  * a `Store` implementation using an in-memory object.
@@ -23,6 +24,10 @@ var util = require('util'),
 function MemoryStore() {
     Store.call(this);
     this.map = Object.create(null);
+
+    // Use 2nd map for objects that were inserted using setObject
+    // to avoid JSON round-trips.
+    this.objectMap = Object.create(null);
 }
 
 MemoryStore.TYPE = 'memory';
@@ -31,25 +36,52 @@ util.inherits(MemoryStore, Store);
 Store.mix(MemoryStore, {
     set: function (key, contents) {
         this.map[key] = contents;
+        delete this.objectMap[key];
     },
 
     get: function (key) {
         if (!this.hasKey(key)) {
             throw new Error('Unable to find entry for [' + key + ']');
         }
+
+        if (Object.prototype.hasOwnProperty.call(this.map, key)) {
+            return this.map[key];
+        }
+
+        this.map[key] = JSON.stringify(this.objectMap[key]);
         return this.map[key];
     },
 
+    getObject: function (key) {
+        if (Object.prototype.hasOwnProperty.call(this.objectMap, key)) {
+            return this.objectMap[key];
+        }
+
+        this.objectMap[key] = JSON.parse(this.get(key));
+        return this.objectMap[key];
+    },
+
+    setObject: function (key, object) {
+        this.objectMap[key] = deepClone(object);
+        delete this.map[key];
+    },
+
     hasKey: function (key) {
-        return Object.prototype.hasOwnProperty.call(this.map, key);
+        return Object.prototype.hasOwnProperty.call(this.map, key) ||
+               Object.prototype.hasOwnProperty.call(this.objectMap, key);
     },
 
     keys: function () {
-        return Object.keys(this.map);
+        var rawKeys = Object.keys(this.map);
+        var objKeys = Object.keys(this.objectMap);
+        return rawKeys.concat(objKeys.filter(function(k) {
+            return rawKeys.indexOf(k) === -1;
+        }));
     },
 
     dispose: function () {
         this.map = Object.create(null);
+        this.objectMap = Object.create(null);
     }
 });
 


### PR DESCRIPTION
Hi there!

I’m working on a project where I’m using `istanbul report` to generate a single report from ~1500 coverage output files, and… it was a bit slow for my taste. :snail:

These commits brought down the time for generating the output from an impressive 5m37s to “just” 1m44s. You can happily turn this PR down, but I’d have felt bad not providing you with these patches.

If this further annoys me and you’re interested, I might write up a patch that spreads up coverage file merging among several worker processes – it seems running `JSON.parse` on the coverage files is where almost all of the time is spent after this, and while that is not easily optimized, it’s certainly parallelizable.

Edit: Tests are failing, but also locally for me without any changes (Node.js v6, x64 Linux). So, take a look when you have the time.
