### PR TITLE
Handle errors when instrumenting 'all sources'

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -221,16 +221,21 @@ function run(args, commandName, enableHooks, callback) {
                         // illustrate the missing coverage.
                         matchFn.files.forEach(function (file) {
                             if (!cov[file]) {
-                                transformer(fs.readFileSync(file, 'utf-8'), file);
+                                try {
+                                  transformer(fs.readFileSync(file, 'utf-8'), file);
 
-                                // When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
-                                // presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,
-                                // as it was never loaded.
-                                Object.keys(instrumenter.coverState.s).forEach(function (key) {
-                                    instrumenter.coverState.s[key] = 0;
-                                });
+                                  // When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
+                                  // presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,
+                                  // as it was never loaded.
+                                  Object.keys(instrumenter.coverState.s).forEach(function (key) {
+                                      instrumenter.coverState.s[key] = 0;
+                                  });
 
-                                cov[file] = instrumenter.coverState;
+                                  cov[file] = instrumenter.coverState;
+                                }
+                                catch(e) {
+                                  console.error('Problem in includeAllSources, unable to process\''+file+'\': ' + e.message )
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
Addresses an issue where the coverage report would silently fail if it
attempted to instrument a file that was 'invalid' for some reason.

Whilst that error once determined was easy enough to rectify (exclusion
rules.) The fact that it silently exited meant it was hard to determine
the cause.

This change ignores any erroring files, but logs the file out to the console.