### PR TITLE
Teamcity reporter modified to send proper coverage values

### DIFF
--- a/lib/report/teamcity.js
+++ b/lib/report/teamcity.js
@@ -63,18 +63,21 @@ Report.mix(TeamcityReport, {
         lines.push('');
         lines.push('##teamcity[blockOpened name=\''+ this.blockName +'\']');
 
+        //Branches Covered
+        lines.push(lineForKey(finalSummary.branches.covered, 'CodeCoverageAbsRCovered'));
+        lines.push(lineForKey(finalSummary.branches.total, 'CodeCoverageAbsRTotal'));
+
         //Statements Covered
-        lines.push(lineForKey(finalSummary.statements.pct, 'CodeCoverageB'));
+        lines.push(lineForKey(finalSummary.statements.covered, 'CodeCoverageAbsBCovered'));
+        lines.push(lineForKey(finalSummary.statements.total, 'CodeCoverageAbsBTotal'));
 
         //Methods Covered
         lines.push(lineForKey(finalSummary.functions.covered, 'CodeCoverageAbsMCovered'));
         lines.push(lineForKey(finalSummary.functions.total, 'CodeCoverageAbsMTotal'));
-        lines.push(lineForKey(finalSummary.functions.pct, 'CodeCoverageM'));
 
         //Lines Covered
         lines.push(lineForKey(finalSummary.lines.covered, 'CodeCoverageAbsLCovered'));
         lines.push(lineForKey(finalSummary.lines.total, 'CodeCoverageAbsLTotal'));
-        lines.push(lineForKey(finalSummary.lines.pct, 'CodeCoverageL'));
 
         lines.push('##teamcity[blockClosed name=\''+ this.blockName +'\']');
 

--- a/test/cli/test-teamcity-report.js
+++ b/test/cli/test-teamcity-report.js
@@ -40,13 +40,14 @@ module.exports = {
         reportLines = fs.readFileSync(outFile, 'utf8');
 
         test.ok(reportLines.indexOf('Code Coverage Summary') > 0);
-        test.ok(reportLines.indexOf('CodeCoverageB') > 0);
+        test.ok(reportLines.indexOf('CodeCoverageAbsRCovered') > 0);
+        test.ok(reportLines.indexOf('CodeCoverageAbsRTotal') > 0);
+        test.ok(reportLines.indexOf('CodeCoverageAbsBCovered') > 0);
+        test.ok(reportLines.indexOf('CodeCoverageAbsBTotal') > 0);
         test.ok(reportLines.indexOf('CodeCoverageAbsMCovered') > 0);
         test.ok(reportLines.indexOf('CodeCoverageAbsMTotal') > 0);
-        test.ok(reportLines.indexOf('CodeCoverageM') > 0);
         test.ok(reportLines.indexOf('CodeCoverageAbsLCovered') > 0);
         test.ok(reportLines.indexOf('CodeCoverageAbsLTotal') > 0);
-        test.ok(reportLines.indexOf('CodeCoverageL') > 0);
 
         test.done();
     },


### PR DESCRIPTION
Changes:

- Added CodeCoverageAbsBCovered, CodeCoverageAbsBTotal  as statement coverage metrics
- Added CodeCoverageAbsRCovered, CodeCoverageAbsRCovered as branch coverage metrics
- Removed CodeCoverageB, CodeCoverageM, CodeCoverageL as TeamCity will not use them.
- Modified test

TeamCity documentation states this:

> You should not publish values CodeCoverageB, CodeCoverageL, CodeCoverageM, CodeCoverageC standing for block/line/method/class coverage percentage. TeamCity will calculate these values using their absolute parts. E.g. CodeCoverageL will be calculated as CodeCoverageAbsLCovered divided by CodeCoverageAbsLTotal. You could publish these values but in this case they will lack decimal parts and will not be useful.