### PR TITLE
Added 'text-folders' view to get folder-recursive totals

### DIFF
--- a/lib/command/report.js
+++ b/lib/command/report.js
@@ -44,6 +44,8 @@ Command.mix(ReportCommand, {
                 formatOption('--root <input-directory>', 'The input root directory for finding coverage files'),
                 formatOption('--dir <report-directory>', 'The output directory where files will be written. This defaults to ./coverage/'),
                 formatOption('--include <glob>', 'The glob pattern to select one or more coverage files, defaults to **/coverage*.json'),
+                formatOption('--depth <depth>', 'depth to show for detail reports (0 unlimited)'),
+                formatOption('--match <string>', 'pattern to match path to show for detail reports'),
                 formatOption('--verbose, -v', 'verbose mode')
             ].join('\n\n'));
 
@@ -68,7 +70,9 @@ Command.mix(ReportCommand, {
                 root: path,
                 dir: path,
                 include: String,
-                verbose: Boolean
+                verbose: Boolean,
+                depth: Number,
+                match: String
             },
             opts = nopt(template, { v : '--verbose' }, args, 0),
             includePattern = opts.include || '**/coverage*.json',
@@ -77,7 +81,9 @@ Command.mix(ReportCommand, {
             config = configuration.loadFile(opts.config, {
                 verbose: opts.verbose,
                 reporting: {
-                    dir: opts.dir
+                    dir: opts.dir,
+                    depth: opts.depth,
+                    match: opts.match
                 }
             }),
             formats = opts.argv.remain,

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,9 @@ function defaultConfig(includeBackCompatAttrs) {
         reporting: {
             print: 'summary',
             reports: [ 'lcov' ],
-            dir: './coverage'
+            dir: './coverage',
+            depth: 0,
+            match: ''
         },
         hooks: {
             'hook-run-in-context': false,
@@ -261,7 +263,7 @@ function ReportingOptions(config) {
  * @method reportConfig
  * @return {Object} detailed report configuration per report format.
  */
-addMethods(ReportingOptions, 'print', 'reports', 'dir', 'reportConfig');
+addMethods(ReportingOptions, 'print', 'reports', 'dir', 'reportConfig','depth', 'match');
 
 function isInvalidMark(v, key) {
     var prefix = 'Watermark for [' + key + '] :';

--- a/lib/report/text-folders.js
+++ b/lib/report/text-folders.js
@@ -1,0 +1,39 @@
+/*
+ Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+var
+    util = require('util'),
+    TextReport = require('./text');
+
+/**
+ * a `Report` implementation that produces text output in a folder-level detailed table.
+ *
+ * Usage
+ * -----
+ *
+ *      var report = require('istanbul').Report.create('text-folders');
+ *
+ * @class TextFolderReport
+ * @extends TextReport
+ * @module report
+ * @constructor
+ * @param {Object} opts - see TextReport
+ */
+function TextFolderReport(opts) {
+    TextReport.call(this);
+}
+
+TextFolderReport.TYPE = 'text-folders';
+util.inherits(TextFolderReport, TextReport);
+
+TextReport.super_.mix(TextFolderReport, {
+
+    node_type: 'dir',
+
+    synopsis: function () {
+        return 'text report that prints a coverage line for every /folder/, typically to console';
+    }
+});
+
+module.exports = TextFolderReport;

--- a/lib/report/text-folders.js
+++ b/lib/report/text-folders.js
@@ -22,6 +22,7 @@ var
  */
 function TextFolderReport(opts) {
     TextReport.call(this);
+    this.opts = opts || {};
 }
 
 TextFolderReport.TYPE = 'text-folders';

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -105,7 +105,9 @@ function tableHeader(maxNameCols, kind) {
     elements.push(formatPct('% Branch'));
     elements.push(formatPct('% Funcs'));
     elements.push(formatPct('% Lines'));
-    kind !== 'dir' && elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
+    if (kind !== 'dir') {
+        elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
+    }
     return elements.join(' |') + ' |';
 }
 
@@ -142,7 +144,9 @@ function tableRow(node, maxNameCols, level, opts) {
     elements.push(formatPct(branches, defaults.classFor('branches', metrics, watermarks)));
     elements.push(formatPct(functions, defaults.classFor('functions', metrics, watermarks)));
     elements.push(formatPct(lines, defaults.classFor('lines', metrics, watermarks)));
-    !isDir && elements.push(formatPct(missingLines.join(','), 'low', MISSING_COL));
+    if (!isDir) {
+        elements.push(formatPct(missingLines.join(','), 'low', MISSING_COL));
+    }
 
     return elements.join(DELIM) + DELIM;
 }
@@ -170,7 +174,9 @@ function makeLine(nameWidth, kind) {
     elements.push(pct);
     elements.push(pct);
     elements.push(pct);
-    kind !== 'dir' && elements.push(padding(MISSING_COL, '-'));
+    if (kind !== 'dir') {
+        elements.push(padding(MISSING_COL, '-'));
+    }
     return elements.join(COL_DELIM) + COL_DELIM;
 }
 

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -15,7 +15,8 @@ var path = require('path'),
     MISSING_COL = 15,
     TAB_SIZE = 1,
     DELIM = ' |',
-    COL_DELIM = '-|';
+    COL_DELIM = '-|',
+    SEP = path.sep || '/';
 
 /**
  * a `Report` implementation that produces text output in a detailed table.
@@ -38,6 +39,7 @@ var path = require('path'),
 function TextReport(opts) {
     Report.call(this);
     opts = opts || {};
+    this.opts = opts;
     this.dir = opts.dir || process.cwd();
     this.file = opts.file;
     this.summary = opts.summary;
@@ -97,13 +99,13 @@ function nodeName(node) {
 
 function tableHeader(maxNameCols, kind) {
     var elements = [],
-      label = {file: 'File', dir: 'Directory'}[kind];
+      label = {file: 'File', dir: 'Directory'}[kind] || 'File';
     elements.push(formatName(label, maxNameCols, 0));
     elements.push(formatPct('% Stmts'));
     elements.push(formatPct('% Branch'));
     elements.push(formatPct('% Funcs'));
     elements.push(formatPct('% Lines'));
-    kind === 'file' && elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
+    kind !== 'dir' && elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
     return elements.join(' |') + ' |';
 }
 
@@ -123,9 +125,10 @@ function collectMissingLines(kind, linesCovered) {
   return missingLines;
 }
 
-function tableRow(node, maxNameCols, level, watermarks, kind) {
+function tableRow(node, maxNameCols, level, opts) {
     var name = nodeName(node),
-        isDir = kind === 'dir',
+        watermarks = opts.watermarks,
+        isDir = opts.kind === 'dir',
         metrics = isDir ? node.recursiveMetrics : node.metrics,
         statements = metrics.statements.pct,
         branches = metrics.branches.pct,
@@ -167,35 +170,39 @@ function makeLine(nameWidth, kind) {
     elements.push(pct);
     elements.push(pct);
     elements.push(pct);
-    kind === 'file' && elements.push(padding(MISSING_COL, '-'));
+    kind !== 'dir' && elements.push(padding(MISSING_COL, '-'));
     return elements.join(COL_DELIM) + COL_DELIM;
 }
 
-function walk(node, nameWidth, array, level, watermarks, kind) {
-    var line;
+function walk(node, nameWidth, array, level, opts) {
+    var kind = opts.kind,
+        depthCheck = opts.depth < 1 || !node.name || node.name.split(SEP).length - 1 <= opts.depth,
+        matchCheck = !opts.match || !node.name || node.name.indexOf(opts.match) > -1,
+        typeCheck = !opts.kind || node.kind === kind,
+        line;
     if (level === 0) {
         line = makeLine(nameWidth, kind);
         array.push(line);
         array.push(tableHeader(nameWidth, kind));
         array.push(line);
     } else {
-        if (node.kind === kind) {
-          array.push(tableRow(node, nameWidth, level, watermarks, kind));
+        if (depthCheck && matchCheck && typeCheck) {
+          array.push(tableRow(node, nameWidth, level, opts));
         }
     }
+
     node.children.forEach(function (child) {
-        walk(child, nameWidth, array, level + 1, watermarks, kind);
+        walk(child, nameWidth, array, level + 1, opts);
     });
+
     if (level === 0) {
         array.push(line);
-        array.push(tableRow(node, nameWidth, level, watermarks, kind));
+        array.push(tableRow(node, nameWidth, level, opts));
         array.push(line);
     }
 }
 
 Report.mix(TextReport, {
-
-    node_type: 'file',
 
     synopsis: function () {
         return 'text report that prints a coverage line for every file, typically to console';
@@ -227,7 +234,12 @@ Report.mix(TextReport, {
                 nameWidth = maxRemaining;
             }
         }
-        walk(root, nameWidth, strings, 0, this.watermarks, this.node_type);
+        walk(root, nameWidth, strings, 0, {
+            watermarks: this.watermarks,
+            kind: this.node_type,
+            depth: this.opts.depth,
+            match: this.opts.match
+        });
         text = strings.join('\n') + '\n';
         if (this.file) {
             mkdirp.sync(this.dir);

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -92,17 +92,18 @@ function formatPct(pct, clazz, width) {
 }
 
 function nodeName(node) {
-    return node.displayShortName() || 'All files';
+    return node.displayShortName() || 'All';
 }
 
-function tableHeader(maxNameCols) {
-    var elements = [];
-    elements.push(formatName('File', maxNameCols, 0));
+function tableHeader(maxNameCols, kind) {
+    var elements = [],
+      label = {file: 'File', dir: 'Directory'}[kind];
+    elements.push(formatName(label, maxNameCols, 0));
     elements.push(formatPct('% Stmts'));
     elements.push(formatPct('% Branch'));
     elements.push(formatPct('% Funcs'));
     elements.push(formatPct('% Lines'));
-    elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
+    kind === 'file' && elements.push(formatPct('Uncovered Lines', undefined, MISSING_COL));
     return elements.join(' |') + ' |';
 }
 
@@ -122,21 +123,23 @@ function collectMissingLines(kind, linesCovered) {
   return missingLines;
 }
 
-function tableRow(node, maxNameCols, level, watermarks) {
+function tableRow(node, maxNameCols, level, watermarks, kind) {
     var name = nodeName(node),
-        statements = node.metrics.statements.pct,
-        branches = node.metrics.branches.pct,
-        functions = node.metrics.functions.pct,
-        lines = node.metrics.lines.pct,
-        missingLines = collectMissingLines(node.kind, node.metrics.linesCovered),
+        isDir = kind === 'dir',
+        metrics = isDir ? node.recursiveMetrics : node.metrics,
+        statements = metrics.statements.pct,
+        branches = metrics.branches.pct,
+        functions = metrics.functions.pct,
+        lines = metrics.lines.pct,
+        missingLines = collectMissingLines(node.kind, metrics.linesCovered),
         elements = [];
 
-    elements.push(formatName(name, maxNameCols, level, defaults.classFor('statements', node.metrics, watermarks)));
-    elements.push(formatPct(statements, defaults.classFor('statements', node.metrics, watermarks)));
-    elements.push(formatPct(branches, defaults.classFor('branches', node.metrics, watermarks)));
-    elements.push(formatPct(functions, defaults.classFor('functions', node.metrics, watermarks)));
-    elements.push(formatPct(lines, defaults.classFor('lines', node.metrics, watermarks)));
-    elements.push(formatPct(missingLines.join(','), 'low', MISSING_COL));
+    elements.push(formatName(name, maxNameCols, level, defaults.classFor('statements', metrics, watermarks)));
+    elements.push(formatPct(statements, defaults.classFor('statements', metrics, watermarks)));
+    elements.push(formatPct(branches, defaults.classFor('branches', metrics, watermarks)));
+    elements.push(formatPct(functions, defaults.classFor('functions', metrics, watermarks)));
+    elements.push(formatPct(lines, defaults.classFor('lines', metrics, watermarks)));
+    !isDir && elements.push(formatPct(missingLines.join(','), 'low', MISSING_COL));
 
     return elements.join(DELIM) + DELIM;
 }
@@ -154,7 +157,7 @@ function findNameWidth(node, level, last) {
     return last;
 }
 
-function makeLine(nameWidth) {
+function makeLine(nameWidth, kind) {
     var name = padding(nameWidth, '-'),
         pct = padding(PCT_COLS, '-'),
         elements = [];
@@ -164,31 +167,36 @@ function makeLine(nameWidth) {
     elements.push(pct);
     elements.push(pct);
     elements.push(pct);
-    elements.push(padding(MISSING_COL, '-'));
+    kind === 'file' && elements.push(padding(MISSING_COL, '-'));
     return elements.join(COL_DELIM) + COL_DELIM;
 }
 
-function walk(node, nameWidth, array, level, watermarks) {
+function walk(node, nameWidth, array, level, watermarks, kind) {
     var line;
     if (level === 0) {
-        line = makeLine(nameWidth);
+        line = makeLine(nameWidth, kind);
         array.push(line);
-        array.push(tableHeader(nameWidth));
+        array.push(tableHeader(nameWidth, kind));
         array.push(line);
     } else {
-        array.push(tableRow(node, nameWidth, level, watermarks));
+        if (node.kind === kind) {
+          array.push(tableRow(node, nameWidth, level, watermarks, kind));
+        }
     }
     node.children.forEach(function (child) {
-        walk(child, nameWidth, array, level + 1, watermarks);
+        walk(child, nameWidth, array, level + 1, watermarks, kind);
     });
     if (level === 0) {
         array.push(line);
-        array.push(tableRow(node, nameWidth, level, watermarks));
+        array.push(tableRow(node, nameWidth, level, watermarks, kind));
         array.push(line);
     }
 }
 
 Report.mix(TextReport, {
+
+    node_type: 'file',
+
     synopsis: function () {
         return 'text report that prints a coverage line for every file, typically to console';
     },
@@ -219,7 +227,7 @@ Report.mix(TextReport, {
                 nameWidth = maxRemaining;
             }
         }
-        walk(root, nameWidth, strings, 0, this.watermarks);
+        walk(root, nameWidth, strings, 0, this.watermarks, this.node_type);
         text = strings.join('\n') + '\n';
         if (this.file) {
             mkdirp.sync(this.dir);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -52,6 +52,9 @@ Reporter.prototype = {
         rptConfig.verbose = config.verbose;
         rptConfig.dir = this.dir;
         rptConfig.watermarks = config.reporting.watermarks();
+        rptConfig.depth =  config.reporting.depth();
+        rptConfig.match = config.reporting.match();
+
         try {
             this.reports[fmt] = Report.create(fmt, rptConfig);
         } catch (ex) {

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -182,7 +182,7 @@ TreeSummary.prototype = {
         );
 
         // initialize recursive metrics with children (file) metrics
-        entry.recursiveMetrics = Object.assign({}, entry.metrics);
+        entry.recursiveMetrics = utils.mergeSummaryObjects(entry.metrics);
 
         // calclulate "java-style" package metrics where there is no hierarchy
         // across packages

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -36,6 +36,21 @@ function findCommonArrayPrefix(args) {
     }
 }
 
+function getParentNode(node, map){
+    if (!node.name) return;
+    var path = node.name.split(SEP),
+        parent,
+        parentNode;
+
+    // remove trailing / and self
+    path.pop(); path.pop();
+
+    while (!parentNode && (parent = path.pop())) {
+        parentNode = map[parent + SEP];
+    }
+    return parentNode && parentNode.name ? parentNode : null;
+}
+
 function Node(fullName, kind, metrics) {
     this.name = fullName;
     this.fullName = fullName;
@@ -130,6 +145,7 @@ TreeSummary.prototype = {
         this.root = root;
         this.map = {};
         this.indexAndSortTree(root, this.map);
+        this.calculateFolderMetrics(this.map);
     },
 
     fixupNodes: function (node, prefix, parent) {
@@ -164,6 +180,10 @@ TreeSummary.prototype = {
             null,
             entry.children.map(function (child) { return child.metrics; })
         );
+
+        // initialize recursive metrics with children (file) metrics
+        entry.recursiveMetrics = Object.assign({}, entry.metrics);
+
         // calclulate "java-style" package metrics where there is no hierarchy
         // across packages
         fileChildren = entry.children.filter(function (n) { return n.kind !== 'dir'; });
@@ -186,6 +206,20 @@ TreeSummary.prototype = {
         });
         node.children.forEach(function (child) {
             that.indexAndSortTree(child, map);
+        });
+    },
+    calculateFolderMetrics: function (map) {
+        var folders = [];
+        Object.keys(map).forEach(function (n) {
+            if (map[n].kind === 'dir') {
+                folders.push(map[n]);
+            }
+        });
+
+        folders.reverse().forEach(function(folder){
+            var parentNode = getParentNode(folder, map);
+            if (!parentNode) return;
+            parentNode.recursiveMetrics = utils.mergeSummaryObjects(parentNode.recursiveMetrics, folder.recursiveMetrics);
         });
     },
     toJSON: function () {

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -37,7 +37,7 @@ function findCommonArrayPrefix(args) {
 }
 
 function getParentNode(node, map){
-    if (!node.name) return;
+    if (!node.name) {return; }
     var path = node.name.split(SEP),
         parent,
         parentNode;
@@ -218,7 +218,7 @@ TreeSummary.prototype = {
 
         folders.reverse().forEach(function(folder){
             var parentNode = getParentNode(folder, map);
-            if (!parentNode) return;
+            if (!parentNode) {return; }
             parentNode.recursiveMetrics = utils.mergeSummaryObjects(parentNode.recursiveMetrics, folder.recursiveMetrics);
         });
     },

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -44,9 +44,9 @@ function getParentNode(node, map){
 
     // remove trailing / and self
     path.pop(); path.pop();
-
     while (!parentNode && (parent = path.pop())) {
-        parentNode = map[parent + SEP];
+        parent = [].concat(path, parent).join(SEP) + SEP;
+        parentNode = map[parent];
     }
     return parentNode && parentNode.name ? parentNode : null;
 }


### PR DESCRIPTION
Working on a sizable project (~700 files) I needed something between the file-based 'text' report and the sparse 'text-summary'.  So I wrote this 'text-folders' report.

``` shell
$ ./lib/cli.js report --root build/coverage/ text-folders
------------------------------|----------|----------|----------|----------|
Directory                     |  % Stmts | % Branch |  % Funcs |  % Lines |
------------------------------|----------|----------|----------|----------|
 istanbul/                    |    96.75 |    90.43 |    98.69 |    97.34 |
 istanbul/lib/                |    96.75 |    90.43 |    98.69 |    97.34 |
 istanbul/lib/command/        |    95.37 |    87.74 |     97.1 |    96.63 |
 istanbul/lib/command/common/ |    92.47 |    83.64 |      100 |    93.33 |
 istanbul/lib/report/         |    95.66 |    81.94 |    98.89 |    96.32 |
 istanbul/lib/report/common/  |    93.75 |       80 |      100 |    93.75 |
 istanbul/lib/store/          |      100 |      100 |      100 |      100 |
 istanbul/lib/util/           |    97.53 |    94.24 |    97.87 |    98.84 |
------------------------------|----------|----------|----------|----------|
All                           |    96.75 |    90.43 |    98.69 |    97.34 |
------------------------------|----------|----------|----------|----------|

Done
```

Still, for large projects, it'd be nice to control the level of detail, even at the folder level.

``` shell
$ ./lib/cli.js report --root build/coverage/ text-folders --depth 2
------------------------------|----------|----------|----------|----------|
Directory                     |  % Stmts | % Branch |  % Funcs |  % Lines |
------------------------------|----------|----------|----------|----------|
 istanbul/                    |    96.75 |    90.43 |    98.69 |    97.34 |
 istanbul/lib/                |    96.75 |    90.43 |    98.69 |    97.34 |
------------------------------|----------|----------|----------|----------|
All                           |    96.75 |    90.43 |    98.69 |    97.34 |
------------------------------|----------|----------|----------|----------|

Done
```

Finally, I wanted to be able to target certain folders in the report, e.g., '/views/' or '/models/'.  Of course, one could do `istanbul report ... | grep views`, but you'd lose the watermarks and styling.

``` shell
$ ./lib/cli.js report --root build/coverage/ text-folders --match common
------------------------------|----------|----------|----------|----------|
Directory                     |  % Stmts | % Branch |  % Funcs |  % Lines |
------------------------------|----------|----------|----------|----------|
 istanbul/lib/command/common/ |    92.47 |    83.64 |      100 |    93.33 |
 istanbul/lib/report/common/  |    93.75 |       80 |      100 |    93.75 |
------------------------------|----------|----------|----------|----------|
All                           |    96.75 |    90.43 |    98.69 |    97.34 |
------------------------------|----------|----------|----------|----------|

Done
```
