### PR TITLE
Make istanbul blazing fast

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -539,9 +539,9 @@
             this.sourceMap = null;
             this.coverState = {
                 path: filename,
-                s: {},
-                b: {},
-                f: {},
+                s: [],
+                b: [],
+                f: [],
                 fnMap: {},
                 statementMap: {},
                 branchMap: {}
@@ -763,10 +763,10 @@
 
             location.skip = ignoring || undefined;
             initValue = initValue || 0;
-            this.currentState.statement += 1;
             sName = this.currentState.statement;
             this.coverState.statementMap[sName] = location;
             this.coverState.s[sName] = initValue;
+            this.currentState.statement += 1;
             return sName;
         },
 
@@ -839,7 +839,7 @@
                     astgen.postIncrement(
                         astgen.subscript(
                             astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
-                            astgen.stringLiteral(sName)
+                            astgen.numericLiteral(sName)
                         )
                     )
                 );
@@ -860,7 +860,7 @@
                 astgen.postIncrement(
                     astgen.subscript(
                         astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('s')),
-                        astgen.stringLiteral(sName)
+                        astgen.numericLiteral(sName)
                     )
                 )
             );
@@ -875,7 +875,6 @@
         },
 
         functionName: function (node, line, location) {
-            this.currentState.func += 1;
             var id = this.currentState.func,
                 ignoring = !!this.currentState.ignoring,
                 name = node.id ? node.id.name : '(anonymous_' + id + ')',
@@ -892,6 +891,7 @@
                 skip: ignoring || undefined
             };
             this.coverState.f[id] = 0;
+            this.currentState.func += 1;
             return id;
         },
 
@@ -916,7 +916,7 @@
                     astgen.postIncrement(
                         astgen.subscript(
                             astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('f')),
-                            astgen.stringLiteral(id)
+                            astgen.numericLiteral(id)
                         )
                     )
                 )
@@ -932,7 +932,6 @@
                 locations = [],
                 i,
                 ignoring = !!this.currentState.ignoring;
-            this.currentState.branch += 1;
             bName = this.currentState.branch;
             for (i = 0; i < pathLocations.length; i += 1) {
                 pathLocations[i].skip = pathLocations[i].skip || ignoring || undefined;
@@ -941,6 +940,7 @@
             }
             this.coverState.b[bName] = paths;
             this.coverState.branchMap[bName] = { line: startLine, type: type, locations: locations };
+            this.currentState.branch += 1;
             return bName;
         },
 
@@ -949,7 +949,7 @@
                 astgen.subscript(
                     astgen.subscript(
                         astgen.dot(astgen.variable(this.currentState.trackerVar), astgen.variable('b')),
-                        astgen.stringLiteral(varName)
+                        astgen.numericLiteral(varName)
                     ),
                     astgen.numericLiteral(branchIndex)
                 ),

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -641,10 +641,7 @@
                         loc.end.column -= offset;
                     }
                 },
-                k,
-                obj,
-                i,
-                locations;
+                i;
 
             coverState.statementMap.forEach(fixer);
             coverState.fnMap.forEach(function (obj) {

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -542,9 +542,9 @@
                 s: [],
                 b: [],
                 f: [],
-                fnMap: {},
-                statementMap: {},
-                branchMap: {}
+                fnMap: [],
+                statementMap: [],
+                branchMap: []
             };
             this.currentState = {
                 trackerVar: generateTrackerVar(filename, this.omitTrackerSuffix),
@@ -646,26 +646,15 @@
                 i,
                 locations;
 
-            obj = coverState.statementMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) { fixer(obj[k]); }
-            }
-            obj = coverState.fnMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) { fixer(obj[k].loc); }
-            }
-            obj = coverState.branchMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) {
-                    locations = obj[k].locations;
-                    for (i = 0; i < locations.length; i += 1) {
-                        fixer(locations[i]);
-                    }
+            coverState.statementMap.forEach(fixer);
+            coverState.fnMap.forEach(function (obj) {
+                fixer(obj.loc);
+            });
+            coverState.branchMap.forEach(function (obj) {
+                for (i = 0; i < obj.locations.length; i += 1) {
+                    fixer(obj.locations[i]);
                 }
-            }
+            });
         },
 
         getPreamble: function (sourceCode, emitUseStrict) {

--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -55,9 +55,8 @@
 
         if (!fileCoverage.l) {
             fileCoverage.l = lineMap = {};
-            Object.keys(statements).forEach(function (st) {
+            statements.forEach(function (count, st) {
                 var line = statementMap[st].start.line,
-                    count = statements[st],
                     prevVal = lineMap[line];
                 if (count === 0 && statementMap[st].skip) { count = 1; }
                 if (typeof prevVal === 'undefined' || prevVal < count) {
@@ -125,9 +124,8 @@
             branchMap = fileCoverage.branchMap,
             ret = { total: 0, covered: 0, skipped: 0 };
 
-        Object.keys(stats).forEach(function (key) {
-            var branches = stats[key],
-                map = branchMap[key],
+        stats.forEach(function (branches, key) {
+            var map = branchMap[key],
                 covered,
                 skipped,
                 i;
@@ -235,15 +233,14 @@
 
         delete ret.l; //remove derived info
 
-        Object.keys(second.s).forEach(function (k) {
-            ret.s[k] += second.s[k];
+        second.s.forEach(function (val, k) {
+            ret.s[k] += val;
         });
-        Object.keys(second.f).forEach(function (k) {
-            ret.f[k] += second.f[k];
+        second.f.forEach(function (val, k) {
+            ret.f[k] += val;
         });
-        Object.keys(second.b).forEach(function (k) {
-            var retArray = ret.b[k],
-                secondArray = second.b[k];
+        second.b.forEach(function (secondArray, k) {
+            var retArray = ret.b[k];
             for (i = 0; i < retArray.length; i += 1) {
                 retArray[i] += secondArray[i];
             }
@@ -339,18 +336,18 @@
                 calledFunctions: 0,
                 coveredFunctions: 0
             };
-            Object.keys(lines).forEach(function (k) {
-                o.lines[k] = lines[k];
+            lines.forEach(function (val, k) {
+                o.lines[k] = val;
                 o.coveredLines += 1;
-                if (lines[k] > 0) {
+                if (val > 0) {
                     o.calledLines += 1;
                 }
             });
-            Object.keys(functions).forEach(function (k) {
+            functions.forEach(function (val, k) {
                 var name = fnMap[k].name + ':' + fnMap[k].line;
-                o.functions[name] = functions[k];
+                o.functions[name] = val;
                 o.coveredFunctions += 1;
-                if (functions[k] > 0) {
+                if (val > 0) {
                     o.calledFunctions += 1;
                 }
             });
@@ -377,9 +374,8 @@
             {mapKey: 'branchMap', hitsKey: 'b'},
             {mapKey: 'fnMap', hitsKey: 'f'}
         ].forEach(function (keys) {
-            Object.keys(fileCoverage[keys.mapKey])
-                .forEach(function (key) {
-                    var map = fileCoverage[keys.mapKey][key];
+            fileCoverage[keys.mapKey]
+                .forEach(function (map, key) {
                     var hits = fileCoverage[keys.hitsKey];
 
                     if (keys.mapKey === 'branchMap') {


### PR DESCRIPTION
A work in progress, closes #556. 

I finally figured out why an `istanbul cover` run in [our project](https://github.com/mapbox/mapbox-gl-js) took 4-5 times as much as the non-istanbul test run! For some reason, V8 has a very hard time accessing string-keyed object properties (`cov.s['0']++` etc.) on every line. Changing coverage stats to use simple arrays instead of objects and do `cov.s[0]++` **gets rid of all the huge overhead**. 

For our project, this change brings a 4-minute coverage run down to 1 minute, almost the same time as a clean test run takes. Awesome!

- [x] convert `*Map` objects to arrays as well
- [x] fix stats iterations in `object-utils.js`
- [ ] update tests to reflect coverage JSON structure change
- [ ] perhaps explore using a shorter id for coverage (e.g. `__cov_FFp_xOkOtMOF6AXOIHanfg` -> `_c`, first var that's not used in any of the scopes in a file)? Should make things faster because of V8 inlining.

cc @gotwarlost  @mramato @jfirebaugh @springmeyer @lucaswoj