### PR TITLE
Update html.js, add null check

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -203,6 +203,9 @@ function annotateStatements(fileCoverage, structuredText) {
             text;
 
         if (type === 'no') {
+            if (!structuredText[startLine]) {
+              return;
+            }
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();


### PR DESCRIPTION
For some reason, I got this error in 0.4.5, adding null check fixed the error.

```js
TypeError: Cannot read property 'text' of undefined
    at /Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:213:47
    at Array.forEach (native)
    at annotateStatements (/Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:193:33)
    at HtmlReport.Report.mix.writeDetailPage (/Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:431:9)
    at /Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:492:26
    at SyncFileWriter.extend.writeFile (/Users/cam/ali/store2/node_modules/istanbul/lib/util/file-writer.js:57:9)
    at FileWriter.extend.writeFile (/Users/cam/ali/store2/node_modules/istanbul/lib/util/file-writer.js:147:23)
    at /Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:491:24
    at Array.forEach (native)
    at HtmlReport.Report.mix.writeFiles (/Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:485:23)
    at /Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:487:22
    at Array.forEach (native)
    at HtmlReport.Report.mix.writeFiles (/Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:485:23)
    at HtmlReport.Report.mix.writeReport (/Users/cam/ali/store2/node_modules/istanbul/lib/report/html.js:569:14)
    at writeReport (/Users/cam/ali/store2/node_modules/karma-coverage/lib/reporter.js:68:16)
    at /Users/cam/ali/store2/node_modules/karma-coverage/lib/reporter.js:296:11
```