### PR TITLE
Fix percent calculation

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -91,10 +91,8 @@
     }
 
     function percent(covered, total) {
-        var tmp;
         if (total > 0) {
-            tmp = 1000 * 100 * covered / total + 5;
-            return Math.floor(tmp / 10) / 100;
+            return Math.floor(10000 * covered / total) / 100;
         } else {
             return 100.00;
         }


### PR DESCRIPTION

current way of computing percentage leads to falsy 100% coverage when numbers are big, e.g.,

```
> function percent(covered, total) {
...         var tmp;
...         if (total > 0) {
.....             tmp = 1000 * 100 * covered / total + 5;
.....             return Math.floor(tmp / 10) / 100;
.....         } else {
.....             return 100.00;
.....         }
...     }
undefined
> percent(20000, 20001)
100
```

Proposed fix:
```
> function percent(covered, total) {
...         var tmp;
...         if (total > 0) {
.....             return Math.floor(10000 * covered / total) / 100;
.....         } else {
.....             return 100.00;
.....         }
...     }
undefined
> percent(20000, 20001)
99.99
> percent(200000, 200001)
99.99
```

