### PR TITLE
enable report with nested directories

### DIFF
--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -100,14 +100,27 @@ TreeSummary.prototype = {
             if (parentPath === SEP + SEP || parentPath === '.' + SEP) {
                 parentPath = SEP + '__root__' + SEP;
             }
-            parent = seen[parentPath];
-            if (!parent) {
-                parent = new Node(parentPath, 'dir');
-                root.addChild(parent);
-                seen[parentPath] = parent;
+
+            var parentsPaths = parentPath.split(SEP),
+                prevParent,
+                lastParent = root,
+                fullPath = '',
+                lastParentPath;
+
+            while (lastParentPath = parentsPaths.shift()) {
+                lastParentPath = lastParentPath + SEP;
+                fullPath += lastParentPath;
+                prevParent = lastParent;
+                lastParent = seen[fullPath];
+                if (!lastParent) {
+                    lastParent = new Node(lastParentPath, 'dir');
+                    prevParent.addChild(lastParent);
+                    seen[fullPath] = prevParent = lastParent;
+                }
             }
-            parent.addChild(node);
-            if (parent === root) { filesUnderRoot = true; }
+
+            lastParent.addChild(node);
+            if (lastParent === root) { filesUnderRoot = true; }
         });
 
         if (filesUnderRoot && arrayPrefix.length > 0) {
@@ -141,8 +154,8 @@ TreeSummary.prototype = {
             node.name = node.name.substring(1);
         }
         if (parent) {
-            if (parent.name !== '__root__' + SEP) {
-                node.relativeName = node.name.substring(parent.name.length);
+            if (parent.name !== '__root__' + SEP && parent.name && node.kind !== 'dir' && node.name.indexOf(parent.name) > -1) {
+                node.relativeName = node.name.split(parent.name)[1]
             } else {
                 node.relativeName = node.name;
             }


### PR DESCRIPTION
I change summerize to return a nested tree of all files,
mabe there should be an option/flag to choose between nested & flat?

I would love this to be enabled, becase I prefer my reports nested by directories