### PR TITLE
Fixes an issue where if there is no JavaScript code to instrument, th…

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -581,7 +581,13 @@
                 generated = generated.code;
             }
 
-            return preamble + '\n' + generated + '\n';
+            var generatedOutput = preamble + '\n';
+
+            if (typeof generated === 'string') {
+                generatedOutput += generated + '\n'
+            }
+
+            return generatedOutput;
         },
         /**
          * Callback based instrumentation. Note that this still executes synchronously in the same process tick


### PR DESCRIPTION
…e returned instrumentedCode has the string '[Object object]' in it which makes the generated file invalid (throws an error during execution).