### PR TITLE
Fix js exception and broken link in report html

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -202,7 +202,7 @@ function annotateStatements(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -233,7 +233,7 @@ function annotateFunctions(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -280,7 +280,7 @@ function annotateBranches(fileCoverage, structuredText) {
                 openSpan = lt + 'span class="branch-' + i + ' ' + (meta.skip ? 'cbranch-skip' : 'cbranch-no') + '"' + title('branch not covered') + gt;
                 closeSpan = lt + '/span' + gt;
 
-                if (count === 0) { //skip branches taken
+                if (count === 0 && structuredText[startLine]) { //skip branches taken
                     if (endLine !== startLine) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();

--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -495,8 +495,9 @@ Report.mix(HtmlReport, {
     standardLinkMapper: function () {
         return {
             fromParent: function (node) {
-                var relativeName = cleanPath(node.relativeName);
-
+                var relativeName = cleanPath(node.relativeName)
+                    .split('/')
+                    .map(encodeURIComponent).join('/');
                 return node.kind === 'dir' ? relativeName + 'index.html' : relativeName + '.html';
             },
             ancestorHref: function (node, num) {


### PR DESCRIPTION
JS Exception fix - happened when I am running ```istanbul report --include "coverage/**/*.json"``` on coverage.json report that I got from protractor-istanbul-plugin
```
/usr/local/lib/node_modules/istanbul/lib/report/html.js:239
                endCol = structuredText[startLine].text.originalLength();
                                                  ^

TypeError: Cannot read property 'text' of undefined
    at /usr/local/lib/node_modules/istanbul/lib/report/html.js:239:51
    at Array.forEach (native)
    at annotateFunctions (/usr/local/lib/node_modules/istanbul/lib/report/html.js:224:26)
    at HtmlReport.writeDetailPage (/usr/local/lib/node_modules/istanbul/lib/report/html.js:427:9)
    at /usr/local/lib/node_modules/istanbul/lib/report/html.js:489:26
    at AsyncFileWriter.processFile (/usr/local/lib/node_modules/istanbul/lib/util/file-writer.js:93:9)
    at /usr/local/lib/node_modules/istanbul/node_modules/async/lib/async.js:987:13
    at Immediate.process (/usr/local/lib/node_modules/istanbul/node_modules/async/lib/async.js:953:21)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
```

In html report, in "File" cell link is broken if folder's/file's name has character that needs URI encoding
For example: src/app/+main/+dashboard/