### PR TITLE
Use esprima tarball instead of git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "url": "git://github.com/gotwarlost/istanbul.git"
     },
     "dependencies": {
-        "esprima": "git://github.com/ariya/esprima.git#harmony",
+        "esprima": "https://github.com/ariya/esprima/tarball/harmony",
         "escodegen": "1.2.x",
         "handlebars": "1.3.x",
         "mkdirp": "0.3.x",


### PR DESCRIPTION
The `harmony` branch of this project is used by qunit in a legacy version as an optional dependency. This branch in turn depends on `ariya/esprima#harmony`. But with a git dependency.

This is problematic when using corporate proxies.

Please accept this PR to enable installs behind proxies. :heart: 