### PR TITLE
fix(lcov): remove uncovered but skipped lines

### DIFF
--- a/lib/report/lcovonly.js
+++ b/lib/report/lcovonly.js
@@ -60,8 +60,10 @@ Report.mix(LcovOnlyReport, {
 
         Object.keys(functions).forEach(function (key) {
             var stats = functions[key],
-                meta = functionMap[key];
-            writer.println('FNDA:' + [ stats, meta.name ].join(','));
+                meta = functionMap[key],
+                covered = stats > 0,
+                skipped = meta.skip;
+            writer.println('FNDA:' + [ (covered || !skipped) ? stats : 1, meta.name ].join(','));
         });
 
         Object.keys(lines).forEach(function (key) {
@@ -75,9 +77,13 @@ Report.mix(LcovOnlyReport, {
             var branchArray = branches[key],
                 meta = branchMap[key],
                 line = meta.line,
-                i = 0;
+                i = 0,
+                covered, skipped;
+
             branchArray.forEach(function (b) {
-                writer.println('BRDA:' + [line, key, i, b].join(','));
+                covered = b > 0;
+                skipped = meta.locations && meta.locations[i] && meta.locations[i].skip;
+                writer.println('BRDA:' + [line, key, i, (covered || !skipped) ? b : 1].join(','));
                 i += 1;
             });
         });


### PR DESCRIPTION
Reporter lcovonly for .lcov files should force coverage for uncovered but skipped lines in collector map.
This will allow SonarQube or other analysis tools that use lcov files to show good coverage measurements.