### PR TITLE
Add relative option to lcov format files.

### DIFF
--- a/lib/report/lcov.js
+++ b/lib/report/lcov.js
@@ -35,7 +35,7 @@ function LcovReport(opts) {
         htmlDir = path.resolve(baseDir, 'lcov-report');
 
     mkdirp.sync(baseDir);
-    this.lcov = new LcovOnlyReport({ dir: baseDir, watermarks: opts.watermarks });
+    this.lcov = new LcovOnlyReport({ dir: baseDir, watermarks: opts.watermarks, relative: opts.relative});
     this.html = new HtmlReport({ dir: htmlDir, watermarks: opts.watermarks, sourceStore: opts.sourceStore});
 }
 

--- a/lib/report/lcovonly.js
+++ b/lib/report/lcovonly.js
@@ -23,10 +23,12 @@ var path = require('path'),
  * @constructor
  * @param {Object} opts optional
  * @param {String} [opts.dir] the directory in which to the `lcov.info` file. Defaults to `process.cwd()`
+ * @param {Boolean} [opts.relative] If true paths reported will be relative to `process.cwd()`. Defaults to `false`
  */
 function LcovOnlyReport(opts) {
     this.opts = opts || {};
     this.opts.dir = this.opts.dir || process.cwd();
+    this.opts.relative = this.opts.relative || false;
     this.opts.file = this.opts.file || this.getDefaultConfig().file;
     this.opts.writer = this.opts.writer || null;
 }
@@ -49,7 +51,7 @@ Report.mix(LcovOnlyReport, {
             summary = utils.summarizeFileCoverage(fc);
 
         writer.println('TN:'); //no test name
-        writer.println('SF:' + fc.path);
+        writer.println('SF:' + (this.opts.relative ? path.relative(process.cwd(), fc.path) : fc.path));
 
         Object.keys(functions).forEach(function (key) {
             var meta = functionMap[key];


### PR DESCRIPTION
When using coverage with lcov files, reports are created using absolute paths. 

There is a good reason to want to generate the report using relative paths. This is both for security reasons and when using an external service in another location such as SonarQube in long delivery pipelines.

This PR offers the option to create the reports with relative paths, this option is turn off by default.

Refers to #104 