### PR TITLE
Add missing line numbers to LCOV report

### DIFF
--- a/lib/report/lcovonly.js
+++ b/lib/report/lcovonly.js
@@ -53,7 +53,7 @@ Report.mix(LcovOnlyReport, {
 
         Object.keys(functions).forEach(function (key) {
             var meta = functionMap[key];
-            writer.println('FN:' + [ meta.line, meta.name ].join(','));
+            writer.println('FN:' + [ meta.loc.start.line, meta.name ].join(','));
         });
         writer.println('FNF:' + summary.functions.total);
         writer.println('FNH:' + summary.functions.covered);
@@ -74,7 +74,7 @@ Report.mix(LcovOnlyReport, {
         Object.keys(branches).forEach(function (key) {
             var branchArray = branches[key],
                 meta = branchMap[key],
-                line = meta.line,
+                line = meta.loc.start.line,
                 i = 0;
             branchArray.forEach(function (b) {
                 writer.println('BRDA:' + [line, key, i, b].join(','));


### PR DESCRIPTION
The fnMap and branchMap are missing line numbers which cause problems with Sonarqube integration.