### PR TITLE
GH-786: Added named anchors for code line numbers.

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -118,7 +118,8 @@ handlebars.registerHelper('show_lines', function (opts) {
         array = [];
 
     for (i = 0; i < maxLines; i += 1) {
-        array[i] = i + 1;
+        var nextNum = i + 1;
+        array[i] = "<a name='L" + nextNum + "'></a><a href='#L" + nextNum + "'>" + nextNum + "</a>";
     }
     return array.join('\n');
 });


### PR DESCRIPTION
Adds links and named anchors for line numbers, to make it easy to refer to a line number within a coverage report.