### PR TITLE
[HTML report] Fixed highlight of conditional expressions

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -286,14 +286,14 @@ function annotateBranches(fileCoverage, structuredText) {
                         endCol = structuredText[startLine].text.originalLength();
                     }
                     text = structuredText[startLine].text;
-                    if (branchMeta[branchName].type === 'if') { // and 'if' is a special case since the else branch might not be visible, being non-existent
+                    if (branchMeta[branchName].type === 'if' || branchMeta[branchName].type === 'cond-expr') { // and 'if' is a special case since the else branch might not be visible, being non-existent
                         text.insertAt(startCol, lt + 'span class="' + (meta.skip ? 'skip-if-branch' : 'missing-if-branch') + '"' +
                             title((i === 0 ? 'if' : 'else') + ' path not taken') + gt +
-                            (i === 0 ? 'I' : 'E')  + lt + '/span' + gt, true, false);
+                            (i === 0 ? 'I' : 'E') + lt + '/span' + gt, true, false);
                     } else {
                         text.wrap(startCol,
                             openSpan,
-                            startLine === endLine ? endCol : text.originalLength(),
+                            startLine === endLine ? endLine : text.originalLength(),
                             closeSpan);
                     }
                 }


### PR DESCRIPTION
There is a problem with processing conditional expressions (such as: a ? b : c). They were highlighted till end of file, to fix this
I corrected line 296 - it was a misstype endCol -> endLine and added 'cond-expr' type of branch to special highlight.