### PR TITLE
chore: add deprecation notice to README, point folks to istanbuljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 [![NPM](https://nodei.co/npm/istanbul.png?downloads=true)](https://nodei.co/npm/istanbul/)
 
+> *Deprecation Notice:* this version of _istanbul_ is deprecated. We will not be
+  landing pull requests or releasing new versions. But don't worry, the [Istanbul 2.0
+  API is now available](https://istanbul.js.org/) and is being actively developed
+  in the new [istanbuljs organization](https://github.com/istanbuljs).
+
 **New** `v0.4.0` now has beautiful HTML reports. Props to Tom MacWright @tmcw for a fantastic job!
 
 * [Features and use cases](#features)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![NPM](https://nodei.co/npm/istanbul.png?downloads=true)](https://nodei.co/npm/istanbul/)
 
-> *Deprecation Notice:* this version of _istanbul_ is deprecated. We will not be
+> *Deprecation Notice:* this version of _istanbul_ is deprecated, we will not be
   landing pull requests or releasing new versions. But don't worry, the [Istanbul 2.0
   API is now available](https://istanbul.js.org/) and is being actively developed
   in the new [istanbuljs organization](https://github.com/istanbuljs).


### PR DESCRIPTION
@gotwarlost @davglass the Istanbuljs 2.0 API is pretty battle tested at this point:

* nyc has over 9.5k repositories using it.
* jest has 11.6K repositories using it.
* babel-plugin-istanbul has 5.13K

I noticed quite a few issues confused about the relationship between istanbul and the istanbuljs org -- along with quite a few open bugs, and pull requests, that it would be great to start helping people with.

@gotwarlost how do you feel about adding a deprecation notice to:

- [ ] the istanbul repo.
- [ ] the GitHub pages branch of this repo.

I think this would help us bring more folks onto your great version 2.0 API.