### PR TITLE
Fix js error

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -202,7 +202,7 @@ function annotateStatements(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine] && structuredText[startLine].text) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -233,7 +233,7 @@ function annotateFunctions(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine] && structuredText[startLine].text) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -280,7 +280,7 @@ function annotateBranches(fileCoverage, structuredText) {
                 openSpan = lt + 'span class="branch-' + i + ' ' + (meta.skip ? 'cbranch-skip' : 'cbranch-no') + '"' + title('branch not covered') + gt;
                 closeSpan = lt + '/span' + gt;
 
-                if (count === 0) { //skip branches taken
+                if (count === 0 && structuredText[startLine] && structuredText[startLine].text) { //skip branches taken
                     if (endLine !== startLine) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();


### PR DESCRIPTION
Fix js error when there is no structuredText of startLine or structuredText of startLine has not text attribute.

Also fixes this issueon karma-coverage: https://github.com/karma-runner/karma-coverage/issues/167 
