### PR TITLE
Ensure Cobertura output conforms to DTD 0.4

### DIFF
--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -95,8 +95,7 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
     writer.println('\t\t<methods>');
     fnMap = fileCoverage.fnMap;
     Object.keys(fnMap).forEach(function (k) {
-        var name = fnMap[k].name,
-            hits = fileCoverage.f[k];
+        var name = fnMap[k].name;
 
         writer.println(
             '\t\t\t<method' +

--- a/lib/report/cobertura.js
+++ b/lib/report/cobertura.js
@@ -90,7 +90,7 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
         attr('filename', path.relative(projectRoot, node.fullPath())) +
         attr('line-rate', metrics.lines.pct / 100.0) +
         attr('branch-rate', metrics.branches.pct / 100.0) +
-        '>');
+        'complexity="0">');
 
     writer.println('\t\t<methods>');
     fnMap = fileCoverage.fnMap;
@@ -101,9 +101,10 @@ function addClassStats(node, fileCoverage, writer, projectRoot) {
         writer.println(
             '\t\t\t<method' +
             attr('name', name) +
-            attr('hits', hits) +
+            attr('line-rate', metrics.lines.pct / 100.0) +
+            attr('branch-rate', metrics.branches.pct / 100.0) +
             attr('signature', '()V') + //fake out a no-args void return
-            '>'
+            'complexity="0">'
         );
 
         //Add the function definition line and hits so that jenkins cobertura plugin records method hits
@@ -169,7 +170,7 @@ function walk(node, collector, writer, level, projectRoot) {
             attr('name', asJavaPackage(node)) +
             attr('line-rate', metrics.lines.pct / 100.0) +
             attr('branch-rate', metrics.branches.pct / 100.0) +
-            '>');
+            'complexity="0">');
         writer.println('\t<classes>');
         node.children.filter(function (child) { return child.kind !== 'dir'; }).
             forEach(function (child) {


### PR DESCRIPTION
Currently the output is not usable on VSTS builds because the XML does not conform to the spec outlined here: http://cobertura.sourceforge.net/xml/coverage-04.dtd.

This modifies the XML structure so the output is considered valid per the spec.