### PR TITLE
Fix TypeError during HTML coverage report when "text" is undefined

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -285,17 +285,19 @@ function annotateBranches(fileCoverage, structuredText) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();
                     }
-                    text = structuredText[startLine].text;
-                    if (branchMeta[branchName].type === 'if') { // and 'if' is a special case since the else branch might not be visible, being non-existent
-                        text.insertAt(startCol, lt + 'span class="' + (meta.skip ? 'skip-if-branch' : 'missing-if-branch') + '"' +
-                            title((i === 0 ? 'if' : 'else') + ' path not taken') + gt +
-                            (i === 0 ? 'I' : 'E')  + lt + '/span' + gt, true, false);
-                    } else {
-                        text.wrap(startCol,
-                            openSpan,
-                            startLine === endLine ? endCol : text.originalLength(),
-                            closeSpan);
-                    }
+                    if (structuredText[startLine]) {
+                        text = structuredText[startLine].text;
+                        if (branchMeta[branchName].type === 'if') { // and 'if' is a special case since the else branch might not be visible, being non-existent
+                            text.insertAt(startCol, lt + 'span class="' + (meta.skip ? 'skip-if-branch' : 'missing-if-branch') + '"' +
+                                title((i === 0 ? 'if' : 'else') + ' path not taken') + gt +
+                                (i === 0 ? 'I' : 'E')  + lt + '/span' + gt, true, false);
+                        } else {
+                            text.wrap(startCol,
+                                openSpan,
+                                startLine === endLine ? endCol : text.originalLength(),
+                                closeSpan);
+                        }
+                    }					
                 }
             }
         }


### PR DESCRIPTION
When using the reporter of type "html", then I am getting the following error when creating a code coverage report:

```
ERROR [coverage]: TypeError: Cannot read property 'text' of undefined
    at D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:288:54
    at Array.forEach (<anonymous>)
    at annotateBranches (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:255:30)
    at HtmlReport.writeDetailPage (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:426:9)
    at D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:489:26
    at SyncFileWriter.writeFile (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\util\file-writer.js:57:9)
    at FileWriter.writeFile (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\util\file-writer.js:147:23)
    at D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:488:24
    at Array.forEach (<anonymous>)
    at HtmlReport.writeFiles (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:482:23)
    at D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:484:22
    at Array.forEach (<anonymous>)
    at HtmlReport.writeFiles (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:482:23)
    at HtmlReport.writeReport (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\node_modules\istanbul\lib\report\html.js:566:14)
    at writeReport (D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\lib\reporter.js:68:16)
    at D:\dev\projects\bennyn\test-coverage\node_modules\karma-coverage\lib\reporter.js:297:11
Done in 2.93s.
```

Although the error above is fired, istanbul still creates a HTML report with index files. I can open them but I cannot click on links like this:

```
http://localhost:63342/test-coverage/coverage/browser/HeadlessChrome%200.0.0%20(Windows%2010%200.0.0)/main/MyClass.ts.html
```

When checking for the existence of `structuredText[startLine]`, then I mitigate the error and istanbul creates a HTML report for me where I can see details of classes. 

I don't know if that is a proper fix because I guess we should find out why `structuredText[startLine]` is not defined but I wanted to create awareness for this problem. At least this fix creates a coverage report in HTML for me.