### PR TITLE
Make double quote usage consistent in HTML header

### DIFF
--- a/lib/report/templates/head.txt
+++ b/lib/report/templates/head.txt
@@ -25,28 +25,28 @@
       <div class='fl pad1y space-right2'>
         <span class="strong">{{pct}}% </span>
         <span class="quiet">Statements</span>
-        <span class='fraction'>{{covered}}/{{total}}</span>
+        <span class="fraction">{{covered}}/{{total}}</span>
       </div>
       {{/with}}
       {{#with metrics.branches}}
       <div class='fl pad1y space-right2'>
         <span class="strong">{{pct}}% </span>
         <span class="quiet">Branches</span>
-        <span class='fraction'>{{covered}}/{{total}}</span>
+        <span class="fraction">{{covered}}/{{total}}</span>
       </div>
       {{/with}}
       {{#with metrics.functions}}
       <div class='fl pad1y space-right2'>
         <span class="strong">{{pct}}% </span>
         <span class="quiet">Functions</span>
-        <span class='fraction'>{{covered}}/{{total}}</span>
+        <span class="fraction">{{covered}}/{{total}}</span>
       </div>
       {{/with}}
       {{#with metrics.lines}}
       <div class='fl pad1y space-right2'>
         <span class="strong">{{pct}}% </span>
         <span class="quiet">Lines</span>
-        <span class='fraction'>{{covered}}/{{total}}</span>
+        <span class="fraction">{{covered}}/{{total}}</span>
       </div>
       {{/with}}
       {{#if_has_ignores metrics}}


### PR DESCRIPTION
Currently, the `fraction` class attribute was used with single quotes, while the others use double quotes. I've converted it to double quotes, to at least have consistency between the header spans. Outside of this, there is still some inconcistency within the templates on attribute quoting, but I considered that to be a too intrusive change.