### PR TITLE
Fix circular dependency found by Node.JS 14

### DIFF
--- a/lib/command/help.js
+++ b/lib/command/help.js
@@ -6,7 +6,6 @@
 var Command = require('./index.js'),
     util = require('util'),
     formatOption = require('../util/help-formatter').formatOption,
-    VERSION = require('../../index').VERSION,
     configuration = require('../config'),
     yaml = require('js-yaml'),
     formatPara = require('../util/help-formatter').formatPara;
@@ -72,7 +71,7 @@ Command.mix(HelpCommand, {
             console.error("\n");
         });
         console.error("Command names can be abbreviated as long as the abbreviation is unambiguous");
-        console.error(this.toolName() + ' version:' + VERSION);
+        console.error(this.toolName() + ' version:' + require('../../index').VERSION);
         console.error("\n");
     },
     run: function (args, callback) {


### PR DESCRIPTION
Istanbul version `0.4.5` seems to produce a circular dependency when using Node.JS 14

```
(node:23084) Warning: Accessing non-existent property 'VERSION' of module exports inside circular dependency
    at emitCircularRequireWarning (internal/modules/cjs/loader.js:650:11)
    at Object.get (internal/modules/cjs/loader.js:664:5)
    at Object.<anonymous> (/home/robert/Documents/HOPR/hoprnet/node_modules/sc-istanbul/lib/command/help.js:9:37)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at /home/robert/Documents/HOPR/hoprnet/node_modules/sc-istanbul/lib/util/factory.js:56:35
```

The problem seems to be that  [VERSION](https://github.com/gotwarlost/istanbul/blob/master/lib/command/help.js#L9) is loaded before [lib/commands/index.js](https://github.com/gotwarlost/istanbul/blob/master/lib/command/index.js) is built and ready to be exported.

Requiring VERSION once it is needed, namely once the `help` command runs, solves the problem.

Referring to issue https://github.com/hoprnet/hoprnet/issues/1241.