### PR TITLE
docs: fix simple typo, delet -> delete

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -49,7 +49,7 @@ function runTests(pat, forceCover) {
         //if any test failed then we cannot obviously run self-coverage
         if (err) { throw err; }
         if (selfCover) {
-            //delet the build dir
+            //delete the build dir
             rimraf.sync(common.getBuildDir());
             //set up environment variable to set CLI and browser
             //tests know that they need to run in self-cover mode


### PR DESCRIPTION
There is a small typo in test/run.js.

Should read `delete` rather than `delet`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md